### PR TITLE
defines SIZEOF_OFF64_T as CMAKE_SIZEOF_VOID_P when off64_t is not defined to fix Mac/AppleClang compilation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -227,6 +227,9 @@ else()
     include(${CMAKE_ROOT}/Modules/CheckTypeSize.cmake)
     set(CMAKE_REQUIRED_DEFINITIONS -D_LARGEFILE64_SOURCE)
     check_type_size("off64_t" SIZEOF_OFF64_T)
+    if(NOT SIZEOF_OFF64_T)
+        set(SIZEOF_OFF64_T ${CMAKE_SIZEOF_VOID_P})
+    endif()
 endif()
 
 


### PR DESCRIPTION
Proposed resolution to define `SIZEOF_OFF64_T` when `off64_t` is not defined, triggering compilation errors using Mac/AppleClang

resolves https://github.com/LLNL/Silo/issues/238