### PR TITLE
Fix int type for length in mem header

### DIFF
--- a/src/score/scctla.c
+++ b/src/score/scctla.c
@@ -172,7 +172,7 @@ static mem_header	*_SC_latest_block ;
  */
 struct s_mem_descriptor {
    short 		ref_count;
-   int                  length;
+   long                 length;
 };
 
 union u_mem_header {

--- a/tests/testpdb.c
+++ b/tests/testpdb.c
@@ -319,7 +319,7 @@ CreateFile (char *filename, char *name, char *type, int num,
     coord0 = MAKE_N(float, 1L<<32);
     for (i = 0; i < 1L<<32; i++) coord0[i] = coord0_data[i%20];
     ind[0] = 0;
-    ind[1] = 1L<<32;
+    ind[1] = (1L<<32) - 1;
     ind[2] = 1;
     if (PD_write_alt(file, "big_coord0", "float", coord0, 1, ind) == 0)
     {

--- a/tests/testpdb.c
+++ b/tests/testpdb.c
@@ -125,7 +125,7 @@ int main ()
 void
 ReadFile (char *filename, char *name)
 {
-    int       i;
+    long      i;
     PDBfile   *file=NULL;
     Group     *group=NULL;
     char      str[256];
@@ -310,8 +310,25 @@ CreateFile (char *filename, char *name, char *type, int num,
         printf("Error writing array.\n");
         exit(EXIT_FAILURE);
     }
-
     SFREE(coord0);
+  
+  #if 0
+     /*
+     * Write a > 2G array.
+     */
+    coord0 = MAKE_N(float, 1L<<32);
+    for (i = 0; i < 1L<<32; i++) coord0[i] = coord0_data[i%20];
+    ind[0] = 0;
+    ind[1] = 1L<<32;
+    ind[2] = 1;
+    if (PD_write_alt(file, "big_coord0", "float", coord0, 1, ind) == 0)
+    {
+        printf("Error writing array.\n");
+        exit(EXIT_FAILURE);
+    }
+    SFREE(coord0);
+  #endif
+
 
     /*
      * Close the file.


### PR DESCRIPTION
A user reported issues with allocations of more than 2^32-1 bytes...

First, I confirm there are NO persistent PDB file consequences to this type. Its wholly confined to SCORE Lite library’s memory allocation headers.

Silo has a configure switch `--enable-normal-sclite-mem-headers` related to this

https://github.com/LLNL/Silo/blob/4.11RC/configure.ac#L393

and it is OFF by default, which means we get “optimized” memory headers (removes a bunch of stuff from SCORE libs allocation routines related to memory tracing).

But, I see in `scctla.c` source file that the “normal” header used long for `length` member and I see no reason why the optimized header shouldn’t also use `long`.

In fact, everywhere else I see that member being used is in statements involving `long` types. So, I honestly think it was a bug for the optimized headers to have used `int` instead of `long` there.

The silo test suite passes with it as `long` though I don’t have any cases where we use SCORE Lite to allocate >2^32-1 bytes of memory.

I gin’d up a test where I allocate 1L<<32 floats in `testpdb.c` and then try to write that object to a PDB file and that in fact also worked though that test takes several mins and so I don't want it there by fiat.
