### PR TITLE
Fix 2D facelist write

### DIFF
--- a/src/hdf5_drv/silo_hdf5.c
+++ b/src/hdf5_drv/silo_hdf5.c
@@ -11819,7 +11819,7 @@ db_hdf5_PutFacelist(
             db_hdf5_compwr(dbfile, DB_INT, 1, &lnodelist, nodelist,
                 m.nodelist/*out*/, friendly_name(_dbfile,name, "_nodelist", 0));
         }
-        if (3==ndims) {
+        if (2==ndims || 3==ndims) {
             db_hdf5_compwr(dbfile, DB_INT, 1, &nshapes, shapecnt,
                 m.shapecnt/*out*/, friendly_name(_dbfile,name, "_shapecnt", 0));
             db_hdf5_compwr(dbfile, DB_INT, 1, &nshapes, shapesize,

--- a/src/pdb_drv/silo_pdb.c
+++ b/src/pdb_drv/silo_pdb.c
@@ -8117,7 +8117,7 @@ db_pdb_PutFacelist(
    DBWriteComponent(dbfile, obj, "nodelist", name, "integer",
                     nodelist, 1, count);
 
-   if (ndims == 3) {
+   if (ndims == 2 || ndims == 3) {
       count[0] = nshapes;
 
       DBWriteComponent(dbfile, obj, "shapecnt", name, "integer",

--- a/src/silo/silo_f.c
+++ b/src/silo/silo_f.c
@@ -894,7 +894,7 @@ DBCALCFL_FC (int *znodelist, int *nnodes, int *origin, int *zshapesize,
 }
 
 /*-------------------------------------------------------------------------
- * Routinex                                                      DBCLOSE_FC
+ * Routine                                                       DBCLOSE_FC
  *
  * Purpose
  *     Close a database.

--- a/src/silo/silo_f.c
+++ b/src/silo/silo_f.c
@@ -731,7 +731,7 @@ DBPUTMAT_FC (int *dbid, FCD_DB name,
        *  that a DB_F77NULL indicates a null array.
        *--------------------------------------------*/
 
-        mixz = (mix_zone[0] == DB_F77NULL) ? NULL : mix_zone;
+        mixz = FPTR(mix_zone);
 
         *status = DBPutMaterial(dbfile, nm, mnm, *nmat, matnos, matlist,
                            dims, *ndims, mix_next, mix_mat, mixz, mix_vf,
@@ -884,8 +884,7 @@ DBCALCFL_FC (int *znodelist, int *nnodes, int *origin, int *zshapesize,
 
     API_BEGIN("dbcalcfl", int, -1) {
         fl = DBCalcExternalFacelist(znodelist, *nnodes, *origin, zshapesize,
-                                    zshapecnt, *nzshapes,
-                               (*matlist == DB_F77NULL) ? NULL : matlist,
+                                    zshapecnt, *nzshapes, FPTR(matlist),
                                     *bnd_method);
         *object_id = DBFortranAllocPointer(fl);
 
@@ -1333,6 +1332,8 @@ DBOPEN_FC (FCD_DB pathname, int *lpathname, int *type, int *mode, int *dbid)
  *     Kathleen Bonnell, Wed Sep 2 15:31:26 PDT 2009
  *     Added SILO_API so symbols are correctly exported on windows.
  *
+ *     Mark C. Miller, Wed Apr 13 18:14:27 PDT 2022
+ *     
  *-------------------------------------------------------------------------*/
 SILO_API FORTRAN
 DBPUTFL_FC (int *dbid, FCD_DB name, int *lname, int *nfaces, int *ndims,
@@ -1370,7 +1371,8 @@ DBPUTFL_FC (int *dbid, FCD_DB name, int *lname, int *nfaces, int *ndims,
          *--------------------------------------------*/
 
         *status = DBPutFacelist(dbfile, nm, *nfaces, *ndims,
-                                nodelist, *lnodelist, *origin, zoneno,
+                                nodelist, *lnodelist, *origin,
+                                FPTR(zoneno),
                                 shapesize, shapecnt, *nshapes,
                                 types, typelist, *ntypes);
 
@@ -5289,7 +5291,7 @@ DBPUTCSGM_FC (int *dbid, FCD_DB name, int *lname, int *ndims, int *nbounds,
 #endif
 
         *status = DBPutCsgmesh(dbfile, nm, *ndims, *nbounds, typeflags,
-            *bndids == DB_F77NULL?0:bndids, coeffs, *lcoeffs, *datatype,
+            FPTR(bndids), coeffs, *lcoeffs, *datatype,
             extents, zl_nm, optlist);
 
         FREE(nm);

--- a/src/silo/silo_f.h
+++ b/src/silo/silo_f.h
@@ -67,7 +67,7 @@ be used for advertising or product endorsement purposes.
 #define FCD_DB char*
 #endif
 
-#define FPTR(X) ((DB_F77NULL==(*X))?(X):NULL)
+#define FPTR(X) ((DB_F77NULL==(*X))?NULL:(X))
 
 #define DBADDIOPT_FC     FC_FUNC (dbaddiopt,DBADDIOPT)
 #define DBADDROPT_FC     FC_FUNC (dbaddropt,DBADDROPT)

--- a/src/silo/silo_f.h
+++ b/src/silo/silo_f.h
@@ -67,7 +67,7 @@ be used for advertising or product endorsement purposes.
 #define FCD_DB char*
 #endif
 
-#define FPTR(X,T)   ((!(X)||DB_F77NULL==(X))?(T)NULL:(T)(X))
+#define FPTR(X) ((DB_F77NULL==(*X))?(X):NULL)
 
 #define DBADDIOPT_FC     FC_FUNC (dbaddiopt,DBADDIOPT)
 #define DBADDROPT_FC     FC_FUNC (dbaddropt,DBADDROPT)


### PR DESCRIPTION
For some reason, writing of 2D facelist info was disabled. I enabled it. All tests pass.

I also fixed definition of `FPTR` macro in Fortran wrapper interface and then used that macro instead of hand-coding instances where it was needed.