### PR TITLE
Miscellaneous CMake improvements

### DIFF
--- a/CMakeBuild_README.txt
+++ b/CMakeBuild_README.txt
@@ -10,6 +10,7 @@ the build dir. Modify CMAKE_INSTALL_PREFIX if you wish to change this.
 Silo CMake vars that control aspects of the build:
 
 SILO_ENABLE_SHARED          Build silo shared library.               DEFAULT : ON
+SILO_ENABLE_SILOCK          Enable building of silock                DEFAULT : ON
 SILO_ENABLE_SILEX           Enable building of silex (requires Qt5)  DEFAULT : OFF
 SILO_ENABLE_BROWSER         Enable building of browser               DEFAULT : ON
 SILO_ENABLE_FORTRAN         Enable Fortran interface to Silo         DEFAULT : ON

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -577,7 +577,7 @@ if(UNIX)
     target_link_libraries(silo m)
 endif()
 
-target_link_libraries(silo "${CMAKE_DL_LIBS}")
+target_link_libraries(silo ${CMAKE_DL_LIBS})
 target_compile_definitions(silo PRIVATE ${SILO_COMPILE_DEFINES})
 add_dependencies(silo pdb_detect)
 target_include_directories(silo PRIVATE ${silo_library_include_dirs})
@@ -658,7 +658,7 @@ if(SILO_ENABLE_SILOCK AND NOT WIN32)
     add_dependencies(silock silo)
     target_link_libraries(silock $<TARGET_LINKER_FILE:silo>)
     if(UNIX)
-        target_link_libraries(silock m dl)
+        target_link_libraries(silock m ${CMAKE_DL_LIBS})
     endif()
     target_include_directories(silock PRIVATE
         ${silo_build_include_dir}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,7 +107,8 @@ file(MAKE_DIRECTORY ${silo_build_include_dir})
 # User options
 ###---------------------------------------------------------------------------
 
-option(SILO_ENABLE_SHARED  "Build silo shared library." ON)
+option(SILO_ENABLE_SHARED "Build silo shared library." ON)
+option(SILO_ENABLE_SILOCK "Enable building of silock" ON)
 option(SILO_ENABLE_SILEX "Enable building of silex (requires Qt5)" OFF)
 option(SILO_ENABLE_BROWSER "Enable building of browser" ON)
 option(SILO_ENABLE_FORTRAN "Enable Fortran interface to Silo" ON)
@@ -139,8 +140,9 @@ CMAKE_DEPENDENT_OPTION(SILO_ENABLE_HZIP "Enable Lindstrom hex/quad mesh compress
 ##
 #  Set up a default INSTALL prefix that is peer to the build directory
 ##
-set(CMAKE_INSTALL_PREFIX ${Silo_BINARY_DIR}/../SiloInstall  CACHE PATH "install prefix" FORCE)
-
+if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
+    set(CMAKE_INSTALL_PREFIX ${Silo_BINARY_DIR}/../SiloInstall  CACHE PATH "install prefix" FORCE)
+endif()
 
 set(BUILD_SHARED_LIBS ${SILO_ENABLE_SHARED})
 
@@ -570,13 +572,16 @@ if(SILO_ENABLE_HDF5 AND HDF5_FOUND)
 endif()
 
 add_library(silo ${silo_library_sources})
-target_compile_definitions(silo PRIVATE ${SILO_COMPILE_DEFINES})
-add_dependencies(silo pdb_detect)
-target_include_directories(silo PRIVATE ${silo_library_include_dirs})
 
 if(UNIX)
     target_link_libraries(silo m)
 endif()
+
+target_link_libraries(silo "${CMAKE_DL_LIBS}")
+target_compile_definitions(silo PRIVATE ${SILO_COMPILE_DEFINES})
+add_dependencies(silo pdb_detect)
+target_include_directories(silo PRIVATE ${silo_library_include_dirs})
+
 
 # add list of public headers to be installed
 set(silo_headers
@@ -622,6 +627,7 @@ endif()
 # setting up for installing Silo CMake config files
 set(silo_targets_name "SiloTargets")
 install(TARGETS silo EXPORT ${silo_targets_name}
+        LIBRARY DESTINATION lib
         PERMISSIONS OWNER_READ OWNER_WRITE
                     GROUP_READ GROUP_WRITE
                     WORLD_READ)
@@ -646,11 +652,14 @@ endif()
 ##
 # silock
 ##
-if(NOT WIN32)
+if(SILO_ENABLE_SILOCK AND NOT WIN32)
     add_executable(silock
         ${Silo_SOURCE_DIR}/tools/silock/silock.c)
     add_dependencies(silock silo)
     target_link_libraries(silock $<TARGET_LINKER_FILE:silo>)
+    if(UNIX)
+        target_link_libraries(silock m dl)
+    endif()
     target_include_directories(silock PRIVATE
         ${silo_build_include_dir}
         ${Silo_SOURCE_DIR}/src/silo)

--- a/tools/browser/CMakeLists.txt
+++ b/tools/browser/CMakeLists.txt
@@ -95,6 +95,8 @@ if(UNIX)
     target_link_libraries(browser m)
 endif()
 
+target_link_libraries(browser "${CMAKE_DL_LIBS}")
+
 if(SILO_ENABLE_HDF5 AND HDF5_FOUND)
     target_link_libraries(browser ${HDF5_C_LIBRARIES})
 endif()

--- a/tools/browser/CMakeLists.txt
+++ b/tools/browser/CMakeLists.txt
@@ -95,7 +95,7 @@ if(UNIX)
     target_link_libraries(browser m)
 endif()
 
-target_link_libraries(browser "${CMAKE_DL_LIBS}")
+target_link_libraries(browser ${CMAKE_DL_LIBS})
 
 if(SILO_ENABLE_HDF5 AND HDF5_FOUND)
     target_link_libraries(browser ${HDF5_C_LIBRARIES})


### PR DESCRIPTION
This pull request contains the changes that were required for Silo to compile and link on my system using CMake. `libm` and `libdl` had to be given to the linker, and a destination library directory name (`lib`) had to be specified in Silo's `install` command.