### PR TITLE
Install pmpio.h to support Cabana builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -591,7 +591,8 @@ set(silo_headers
     ${silo_build_include_dir}/silo.h
     ${Silo_SOURCE_DIR}/src/silo/silo.inc
     ${Silo_SOURCE_DIR}/src/silo/silo_f9x.inc
-    ${Silo_SOURCE_DIR}/src/silo/silo_exports.h)
+    ${Silo_SOURCE_DIR}/src/silo/silo_exports.h
+    ${Silo_SOURCE_DIR}/src/silo/pmpio.h)
 
 if(WIN32)
     list(APPEND silo_headers ${Silo_SOURCE_DIR}/src/silo/silo_win32_compatibility.h)


### PR DESCRIPTION
[Cabana](https://github.com/ECP-copa/Cabana) looks for `pmpio.h` when building its binaries, but that file only exists in Silo's source directory, not in Silo's install location. In a way, that seems like Cabana's problem, but since I can't find any other repo containing `pmpio.h`, I thought adding it to the install cmake target might be a fine solution. 
@streeve