### PR TITLE
Patch from Dave Bremer

### DIFF
--- a/src/silo/silo.c
+++ b/src/silo/silo.c
@@ -4430,6 +4430,7 @@ DBClose(DBfile *dbfile)
 {
     int            id;
     int            retval;
+    SILO_Globals_t *tmp_file_scope_globals;
 
     API_BEGIN2("DBClose", int, -1, api_dummy) {
         if (!dbfile)
@@ -4447,8 +4448,9 @@ DBClose(DBfile *dbfile)
             free(dbfile->pub.file_lib_version);
         db_unregister_file(dbfile);
 
+	tmp_file_scope_globals = dbfile->pub.file_scope_globals; 
         retval = (dbfile->pub.close) (dbfile);
-        free(dbfile->pub.file_scope_globals);
+        free(tmp_file_scope_globals);
         API_RETURN(retval);
     }
     API_END_NOPOP; /*BEWARE: If API_RETURN above is removed use API_END */


### PR DESCRIPTION
Fixes poorly designed freeing of file scope gloabls. Thanks to Dave Bremer.

While doing some testing, I found a memory error in DBClose().  I made a patch and wanted to offer it for inclusion in the Silo source.  It's a two-line change, so I could hand it to you directly, or submit it through GitHub.  

Current code:
```
        retval = (dbfile->pub.close) (dbfile);
        free(dbfile->pub.file_scope_globals);
```
Proposed change:
```
        SILO_Globals_t *tmp_file_scope_globals = dbfile->pub.file_scope_globals;
        retval = (dbfile->pub.close) (dbfile);
        free(tmp_file_scope_globals);
```

The dbfile->pub.close() function tends to call free on dbfile, so the pointer at dbfile->pub.file_scope_globals is in freed memory.  It tends to work, unless you use a Windows debug build, or if you set MALLOC_PERTURB_ on Linux, which writes a value into a freed buffe