### PR TITLE
Fix PJ cache for GetComponentType

### DIFF
--- a/src/pdb_drv/silo_pdb.c
+++ b/src/pdb_drv/silo_pdb.c
@@ -829,6 +829,9 @@ PJ_GetComponent (PDBfile *file, char const *objname, char const *compname) {
  *
  *  Modified
  *
+ *    Mark C. Miller, Thu Aug 24 22:41:23 PDT 2023
+ *    Add use_PJcache_group==0 to conditions controlling whether a new
+ *    call to PJ_GetObject is made.
  *--------------------------------------------------------------------
  */
 INTERNAL int
@@ -840,7 +843,7 @@ PJ_GetComponentType (PDBfile *file, char const *objname, char const *compname)
 
    /* If there is no cached group, or we are interested in a
     * different object, get the one we want.  */
-   if(cached_group == NULL || cached_obj_name == NULL ||
+   if(use_PJgroup_cache == 0 || cached_group == NULL || cached_obj_name == NULL ||
       (!STR_EQUAL(cached_obj_name, objname)))
    {
        char       *result = NULL;


### PR DESCRIPTION
Getting objects in python module using absolute or relative paths (except for ojects in the cwd) was not working.

The PDB driver has a caching mechanism with various variables controlling it. One is an integer flag, `use_PJgroup_cache`. That flag was being used to control *some* behavior of the cache but not all of it. I added a test for it as a condition to make a new `PJ_GetObject()` call from within `PJ_GetComponentType()`.

This corrected the behavior of the python module.