### PR TITLE
Msvc detection

### DIFF
--- a/CMake/SiloFindHDF5.cmake
+++ b/CMake/SiloFindHDF5.cmake
@@ -82,7 +82,7 @@ if(HDF5_FOUND)
 
         add_custom_command(TARGET copy_deps POST_BUILD
              COMMAND ${CMAKE_COMMAND} -E copy_if_different
-             ${HDF5_DLL} ${Silo_BINARY_DIR}/bin/$<CONFIG>)
+             ${HDF5_DLL} ${Silo_BINARY_DIR}/bin/$<$<BOOL:${is_multi_config}>:$<CONFIG>>/)
     endif()
 
 else()

--- a/CMake/SiloFindSzip.cmake
+++ b/CMake/SiloFindSzip.cmake
@@ -82,7 +82,7 @@ if(SZIP_FOUND)
 
         add_custom_command(TARGET copy_deps POST_BUILD
              COMMAND ${CMAKE_COMMAND} -E copy_if_different
-             ${SZIP_DLL} ${Silo_BINARY_DIR}/bin/$<CONFIG>)
+             ${SZIP_DLL} ${Silo_BINARY_DIR}/bin/$<$<BOOL:${is_multi_config}>:$<CONFIG>>/)
 
     endif()
 else()

--- a/CMake/SiloFindZlib.cmake
+++ b/CMake/SiloFindZlib.cmake
@@ -83,7 +83,7 @@ if(ZLIB_FOUND)
 
         add_custom_command(TARGET copy_deps POST_BUILD
              COMMAND ${CMAKE_COMMAND} -E copy_if_different
-             ${ZLIB_DLL} ${Silo_BINARY_DIR}/bin/$<CONFIG>)
+             ${ZLIB_DLL} ${Silo_BINARY_DIR}/bin/$<$<BOOL:${is_multi_config}>:$<CONFIG>>/)
 
     endif()
 else()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -629,9 +629,6 @@ install(FILES ${silo_headers} DESTINATION include
 
 
 if(SILO_ENABLE_HDF5 AND HDF5_FOUND)
-    # since we change the ouputname from silo to siloh5 when building
-    # with HDF5, will use $<TARGET_LINKER_FILE:silo> in place of plain 'silo'
-    # when telling broswer and silex to link with silo
     set_target_properties(silo PROPERTIES OUTPUT_NAME siloh5)
     target_link_libraries(silo ${HDF5_C_LIBRARIES})
     target_include_directories(silo PRIVATE ${HDF5_INCLUDE_DIRS})
@@ -668,8 +665,7 @@ endif()
 if(SILO_ENABLE_SILOCK AND NOT WIN32)
     add_executable(silock
         ${Silo_SOURCE_DIR}/tools/silock/silock.c)
-    add_dependencies(silock silo)
-    target_link_libraries(silock $<TARGET_LINKER_FILE:silo>)
+    target_link_libraries(silock silo)
     if(UNIX)
         target_link_libraries(silock m ${CMAKE_DL_LIBS})
     endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,6 +97,9 @@ endif()
 # turn on folders (VS IDE, ignored otherwise)
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
+# Query if the generator is multi-config or not.
+get_property(is_multi_config GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
+
 #
 # create an include dir for generated include files
 #
@@ -615,7 +618,7 @@ if(WIN32)
         # copy silo dll to build/bin dir
         add_custom_command(TARGET copy_deps POST_BUILD
              COMMAND ${CMAKE_COMMAND} -E copy_if_different
-             $<TARGET_FILE:silo> ${Silo_BINARY_DIR}/bin/$<CONFIG>)
+             $<TARGET_FILE:silo> ${Silo_BINARY_DIR}/bin/$<$<BOOL:${is_multi_config}>:$<CONFIG>>/)
     endif()
 endif()
 

--- a/src/hdf5_drv/H5FDsilo.c
+++ b/src/hdf5_drv/H5FDsilo.c
@@ -496,7 +496,7 @@ static herr_t H5FD_silo_write(H5FD_t *lf, H5FD_mem_t type, hid_t fapl_id, haddr_
                 size_t size, const void *buf);
 static herr_t H5FD_silo_truncate(H5FD_t *_file, hid_t dxpl_id, hbool_t closing);
 
-#ifndef _WIN32
+#ifndef _MSC_VER
 #warning REMOVE ME
 #endif
 #if 0
@@ -2001,7 +2001,7 @@ H5FD_silo_get_eof(const H5FD_t *_file, H5FD_mem_t type)
 H5FD_silo_get_eof(const H5FD_t *_file)
 #endif
 {
-#ifndef _WIN32
+#ifndef _MSC_VER
 #warning TAKE ADVANTAGE OF TYPE INFO HERE
 #endif
     const H5FD_silo_t	*file = (const H5FD_silo_t *)_file;

--- a/src/hdf5_drv/silo_hdf5.c
+++ b/src/hdf5_drv/silo_hdf5.c
@@ -2154,7 +2154,7 @@ db_hdf5_init(void)
 
 #if HDF5_VERSION_GE(1,8,0) && !defined(H5_USE_16_API)
     db_hdf5_hzip_class.version = H5Z_CLASS_T_VERS;
-#ifndef _WIN32
+#ifndef _MSC_VER
 #warning SHOULD WE DISABLE HZIP AND FPZIP ENCODING
 #endif
     db_hdf5_hzip_class.encoder_present = 1;
@@ -2800,7 +2800,7 @@ db_hdf5_InitCallbacks(DBfile_hdf5 *dbfile, int target)
     dbfile->pub.newtoc = db_hdf5_NewToc;
     dbfile->pub.mkdir = db_hdf5_MkDir;
     dbfile->pub.cpdir = db_hdf5_CpDir;
-#ifndef _WIN32
+#ifndef _MSC_VER
 #warning GET RID OF CPLISTEDOBJECTS
 #endif
     dbfile->pub.cpnobjs = db_hdf5_CpListedObjects;
@@ -3352,7 +3352,7 @@ db_hdf5_set_compression(DBfile *dbfile, int flags)
             have_zfp = TRUE;
 #endif
     }
-#ifndef _WIN32
+#ifndef _MSC_VER
 #warning WHAT ABOUT NULL RETURN FROM DBGETCOMPRESSION
 #endif
 /* Handle some global compression parameters */
@@ -3385,7 +3385,7 @@ db_hdf5_set_compression(DBfile *dbfile, int flags)
             return (-1);
         }
     }
-#ifndef _WIN32
+#ifndef _MSC_VER
 #warning FIX MISSING .compressionMinsize member
 #endif
 #if 0
@@ -3405,7 +3405,7 @@ db_hdf5_set_compression(DBfile *dbfile, int flags)
     }
 #endif
 
-#ifndef _WIN32
+#ifndef _MSC_VER
 #warning QUERY FILE LEVEL COMPRESSION PARAMS HERE
 #endif
     opt_flag = SILO_Globals.compressionErrmode == COMPRESSION_ERRMODE_FALLBACK ?
@@ -4132,7 +4132,7 @@ load_toc(hid_t grp, char const *name, H5L_info_t const *dummy, void *_toc)
     }
 
     /* Append to table of contents */
-#ifndef _WIN32
+#ifndef _MSC_VER
 #warning REVISIT THIS CODE BLOCK
 #endif
 #if 0
@@ -4749,7 +4749,7 @@ db_hdf5_resolvename(DBfile *_dbfile,
     static int const nmax = 32;
     static char *cbuf[32] = {0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
                              0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0};
-#ifndef _WIN32
+#ifndef _MSC_VER
 #warning HARD CODED SIZE HERE
 #endif
     static char cwgname[4096];
@@ -5020,7 +5020,7 @@ db_hdf5_process_file_options(int opts_set_id, int mode, hid_t *fcpl)
     /* Handle cases where we are running on Windows. If a client
        request anything other than the default driver, we issue
        a warning message and continue only on windows (default) vfd. */
-#if !defined(_WIN32)
+#if !defined(_MSC_VER)
 #warning REMOVED WINDOWS SPECIFIC CHECK
 #endif
 #if 0
@@ -5111,7 +5111,7 @@ db_hdf5_process_file_options(int opts_set_id, int mode, hid_t *fcpl)
         /* default HDF5 mpi drivers */
         case DB_FILE_OPTS_H5_DEFAULT_MPIP:
         {
-#ifndef _WIN32
+#ifndef _MSC_VER
 #warning DO WE STILL NEED THIS
 #endif
             H5Pclose(retval);
@@ -5171,7 +5171,7 @@ db_hdf5_process_file_options(int opts_set_id, int mode, hid_t *fcpl)
                 h5status |= H5Pset_driver(retval, new_driver_id, p);
             }
 
-#if !defined(_WIN32)
+#if !defined(_MSC_VER)
 #warning REMOVED WINDOWS SPECIFIC CHECK
 #endif
 #if 0
@@ -5291,7 +5291,7 @@ db_hdf5_process_file_options(int opts_set_id, int mode, hid_t *fcpl)
                         }
 
                         /* Allocate buffer to communicate user data to callbacks */
-#ifndef _WIN32
+#ifndef _MSC_VER
 #warning PUT UDATA POINTER IN DBFILE pointer so it can be freed with file is closed.
 #endif
                         if (NULL == (udata = (db_hdf5_H5LT_file_image_ud_t *)malloc(sizeof(db_hdf5_H5LT_file_image_ud_t))))
@@ -5440,7 +5440,7 @@ db_hdf5_process_file_options(int opts_set_id, int mode, hid_t *fcpl)
                     }
                     else
                     {
-#ifndef _WIN32
+#ifndef _MSC_VER
 #warning DO WE STILL NEED THIS
 #endif
                         H5Pclose(retval);
@@ -5526,7 +5526,7 @@ db_hdf5_process_file_options(int opts_set_id, int mode, hid_t *fcpl)
         }
     }
 
-#ifndef _WIN32
+#ifndef _MSC_VER
 #warning FIX THIS
 #endif
 #if 0
@@ -5915,7 +5915,7 @@ db_hdf5_Open(char const *name, int mode, int opts_set_id)
     }
 
     faprops = db_hdf5_file_accprops(opts_set_id, mode, 0);
-#ifndef _WIN32
+#ifndef _MSC_VER
 #warning QUERY FILE IMAGE STUFF HERE TO GET UDATA PTR
 #endif
 
@@ -6006,7 +6006,7 @@ db_hdf5_Create(char const *name, int mode, int target, int opts_set_id, char con
         if (fcprops == -1)
         {
             fcprops = H5Pcreate(H5P_FILE_CREATE);
-#ifndef _WIN32
+#ifndef _MSC_VER
 #warning BACKWARD COMPAT ISSUE FOR HDF5
 #endif
             /*H5Pset_istore_k(fcprops, 1);*/
@@ -6043,7 +6043,7 @@ db_hdf5_Create(char const *name, int mode, int target, int opts_set_id, char con
     *fidp = fid;
     dbfile->pub.GrabId = (void*) fidp;
     dbfile->fid = fid;
-#ifndef _WIN32
+#ifndef _MSC_VER
 #warning FIX FILE SCOPE GLOBAL INITIALIZATION
 #endif
 #if 0
@@ -6509,7 +6509,7 @@ copy_obj(hid_t hobj, char const *name, void *op_data)
             UNWIND();
         }
         asize = H5Tget_size(atype);
-#ifndef _WIN32
+#ifndef _MSC_VER
 #warning WHY THIS SIZE
 #endif
         msize = MAX(asize, 3*1024);
@@ -6680,7 +6680,7 @@ db_hdf5_CpDir(DBfile *_dbfile, char const *srcDir,
     return 0;
 }
 
-#ifndef _WIN32
+#ifndef _MSC_VER
 #warning REMOVE THIS MAYBE
 #endif
 SILO_CALLBACK int
@@ -7419,7 +7419,7 @@ db_hdf5_WriteObject(DBfile *_dbfile,    /*File to write into */
                 foffset += H5Tget_size(dbfile->T_double);
             } else if (!strncmp(obj->pdb_names[i], "'<s>", 4)) {
                 size_t len = strlen(obj->pdb_names[i]+4)-1;
-#ifndef _WIN32
+#ifndef _MSC_VER
 #warning COMPATABILITY ISSUE
 #endif
                 hid_t str_type;
@@ -7794,7 +7794,7 @@ db_hdf5_get_var_byte_length(DBfile *_dbfile, char const *name, int use_file_size
     hsize_t     nbytes_big;
     int         nbytes_small=-1;
 
-#ifndef _WIN32
+#ifndef _MSC_VER
 #warning REMOVED db_perror CALLS
 #endif
     PROTECT {
@@ -8442,7 +8442,7 @@ db_hdf5_WriteCKZ(DBfile *_dbfile, char const *vname, void const *var,
                    UNWIND();
                }
            }
-#ifndef _WIN32
+#ifndef _MSC_VER
 #warning WHAT IF EXISTING DATASET WAS COMPRESSED
 #endif
        } else {
@@ -8486,7 +8486,7 @@ db_hdf5_WriteCKZ(DBfile *_dbfile, char const *vname, void const *var,
            db_perror(vname, E_CALLFAIL, me);
            UNWIND();
        }
-#ifndef _WIN32
+#ifndef _MSC_VER
 #warning COMPARE TO -1 OR TO NEGATIVE
 #endif
        if (dset_type != -1)
@@ -8510,7 +8510,7 @@ db_hdf5_WriteCKZ(DBfile *_dbfile, char const *vname, void const *var,
        H5E_BEGIN_TRY {
            H5Dclose(dset);
            H5Sclose(space);
-#ifndef _WIN32
+#ifndef _MSC_VER
 #warning COMPARE TO -1 OR NEGATIVE
 #endif
            if (dset_type != -1)
@@ -8737,7 +8737,7 @@ db_hdf5_GetObject(DBfile *_dbfile, char const *name)
         }
 
         /* Add members to the DBobject */
-#ifndef _WIN32
+#ifndef _MSC_VER
 #warning THIS IFDEFD CODE IS IN TRANSITION TO BETTER GENERIC OBJECTS
 #endif
         for (i=0; i<nmembs; i++) {
@@ -8836,14 +8836,14 @@ db_hdf5_GetObject(DBfile *_dbfile, char const *name)
             H5Tclose(member_type);
         }
 
-#ifndef _WIN32
+#ifndef _MSC_VER
 #warning REVISIT THIS CLEANUP CODE. IS THERE A BETTER SYMBOLIC VALUE THAN -1
 #endif
         /* Cleanup */
         H5Tclose(atype);
         H5Aclose(attr);
         H5Tclose(o);
-#ifndef _WIN32
+#ifndef _MSC_VER
 #warning USE FREE() MACRO HERE
 #endif
         free(file_value);
@@ -8857,7 +8857,7 @@ db_hdf5_GetObject(DBfile *_dbfile, char const *name)
             H5Aclose(attr);
             H5Tclose(o);
         } H5E_END_TRY;
-#ifndef _WIN32
+#ifndef _MSC_VER
 #warning USE FREE() MACRO HERE
 #endif
         if (file_value) free(file_value);
@@ -11520,7 +11520,7 @@ db_hdf5_PutUcdvar(DBfile *_dbfile, char const *name, char const *meshname, int n
         for (i=0; i<nvars && nels; i++) {
             db_hdf5_compwrz(dbfile, datatype, 1, &nels, vars[i],
                 m.value[i]/*out*/, friendly_name(_dbfile,varnames[i], "_data", 0), compressionFlags);
-//#ifndef _WIN32
+//#ifndef _MSC_VER
 //#warning WHY NOT COMPRESS MIX DATA TOO
 //#endif
             if (mixvars && mixvars[i] && mixlen>0) {
@@ -14367,7 +14367,7 @@ db_hdf5_PutMultimat(DBfile *_dbfile, char const *name, int nmats, char const * c
          * material names.
          */
         /* Write raw data arrays */
-#ifndef _WIN32
+#ifndef _MSC_VER
 #warning REPLACE WITH STRING UTILITIES
 #endif
         if (nmats > 0 && matnames)
@@ -14407,7 +14407,7 @@ db_hdf5_PutMultimat(DBfile *_dbfile, char const *name, int nmats, char const * c
             db_hdf5_compwr(dbfile, DB_CHAR, 1, &len, tmp,
                 m.mat_colors/*out*/, friendly_name(_dbfile,name,"_matcolors", 0));
             FREE(tmp);
-#ifndef _WIN32
+#ifndef _MSC_VER
 #warning IS THIS TAKEN CARE OF ELSEWHERE
 #endif
             _mm._matcolors = 0;
@@ -14419,7 +14419,7 @@ db_hdf5_PutMultimat(DBfile *_dbfile, char const *name, int nmats, char const * c
             db_hdf5_compwr(dbfile, DB_CHAR, 1, &len, tmp,
                 m.material_names/*out*/, friendly_name(_dbfile,name,"_material_names", 0));
             FREE(tmp);
-#ifndef _WIN32
+#ifndef _MSC_VER
 #warning IS THIS TAKEN CARE OF ELSEWHERE
 #endif
             _mm._matnames = 0;

--- a/src/hdf5_drv/silo_hdf5_private.h
+++ b/src/hdf5_drv/silo_hdf5_private.h
@@ -107,7 +107,7 @@ SILO_CALLBACK int db_hdf5_SetDir(DBfile *_dbfile, char const *name);
 SILO_CALLBACK int db_hdf5_GetDir(DBfile *_dbfile, char *name/*out*/);
 SILO_CALLBACK int db_hdf5_CpDir(DBfile *_dbfile, char const *srcDir,
                            DBfile *dstFile, char const *dstDir);
-#ifndef _WIN32
+#ifndef _MSC_VER
 #warning REMOVE db_hdf5_CpListedObjects
 #endif
 SILO_CALLBACK int db_hdf5_CpListedObjects(int nobjs,

--- a/src/pdb/pdb.c
+++ b/src/pdb/pdb.c
@@ -1806,7 +1806,7 @@ int lite_PD_set_buffer_size(int s)
     return lite_PD_buffer_size;
 }
 
-#ifndef _WIN32
+#ifndef _MSC_VER
 #warning MOVE TO PDLOW.C
 #endif
 char *lite_PD_get_error(void)
@@ -1814,7 +1814,7 @@ char *lite_PD_get_error(void)
     return lite_PD_err;
 }
 
-#ifndef _WIN32
+#ifndef _MSC_VER
 #warning MOVE TO PDMEMB.C
 #endif
 syment *lite_PD_query_entry(PDBfile *file, char *name, char *fullname)
@@ -1822,7 +1822,7 @@ syment *lite_PD_query_entry(PDBfile *file, char *name, char *fullname)
     return lite_PD_inquire_entry(file, name, TRUE, fullname);
 }
 
-#ifndef _WIN32
+#ifndef _MSC_VER
 #warning MOVE TO PDLOW.C
 #endif
 int lite_PD_get_entry_info(syment *ep, char **ptyp, long *pni, int *pnd, long **pdim)
@@ -1873,7 +1873,7 @@ int lite_PD_get_entry_info(syment *ep, char **ptyp, long *pni, int *pnd, long **
   return(rv);
 }
 
-#ifndef _WIN32
+#ifndef _MSC_VER
 #warning MOVE TO PDLOW.C
 #endif
 void lite_PD_free_entry_info(char *typ, long *pdim)
@@ -1882,7 +1882,7 @@ void lite_PD_free_entry_info(char *typ, long *pdim)
   SFREE(pdim);
 }
 
-#ifndef _WIN32
+#ifndef _MSC_VER
 #warning MOVE TO PDLOW.C
 #endif
 void lite_PD_rel_entry_info(syment *ep, char *type, long *dims)
@@ -1892,14 +1892,14 @@ void lite_PD_rel_entry_info(syment *ep, char *type, long *dims)
 }
 
 /* 21Mar17 for Rob Managan */
-#ifndef _WIN32
+#ifndef _MSC_VER
 #warning MOVE TO PDBDIR.C
 #endif
 int lite_PD_ln(PDBfile *file, char *oldname, char *newname)
 {
   /* Courtesy of Rob Managan */
   syment *oldep;
-#ifndef _WIN32
+#ifndef _MSC_VER
 #warning MAYBE INCREASE MAXLINE FOR LEOSPACT
 #endif
   char newpath[MAXLINE], oldpath[MAXLINE], dirname[MAXLINE];
@@ -1976,7 +1976,7 @@ int lite_PD_ln(PDBfile *file, char *oldname, char *newname)
   return(TRUE);
 }
 
-#ifndef _WIN32
+#ifndef _MSC_VER
 #warning SHOULD GO IN PDBMM.c
 #endif
 void *_lite_PD_alloc_entry(PDBfile *file, char *type, long nitems)

--- a/tests/CMake/SiloTestFunctions.cmake
+++ b/tests/CMake/SiloTestFunctions.cmake
@@ -81,12 +81,8 @@ function(silo_add_test)
 
 
     add_executable(${sat_NAME} ${sat_SRC})
-    if(WIN32)
-        # change output directory using generator expression to avoid
-        # VS adding per-configuration subdir
-        set_target_properties(${sat_NAME} PROPERTIES RUNTIME_OUTPUT_DIRECTORY
-            ${silo_test_output_dir}/$<$<CONFIG:Debug>:>)
-    endif()
+    set_target_properties(${sat_NAME} PROPERTIES RUNTIME_OUTPUT_DIRECTORY
+        ${silo_test_output_dir})
     if("LANG" IN_LIST sat_KEYWORDS_MISSING_VALUES)
         message(WARNING "silo_add_test: LANG argument is missing a value.")
         return()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -59,19 +59,8 @@ project(SILO_TESTS)
 # Set the output dir for test executables
 ###-------------------------------------------------------------------------------------
 
-if(WIN32)
-    ##
-    # For windows, the standard output dir (${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>) causes
-    # problems with the script writing used when creating test-runners because the value
-    # of $<CONFIG> isn't known until build time.  Instead use a non-configuration location
-    # subdir directly off build-dir
-    ##
-    set(silo_test_output_dir ${Silo_BINARY_DIR}/all_tests/)
-    file(MAKE_DIRECTORY ${silo_test_output_dir})
-else()
-    # runtime output dir is bin, so append bin to current binary dir
-    set(silo_test_output_dir ${CMAKE_CURRENT_BINARY_DIR}/bin)
-endif()
+# runtime output dir is bin, so append bin to current binary dir
+set(silo_test_output_dir ${CMAKE_CURRENT_BINARY_DIR}/bin/$<$<BOOL:${is_multi_config}>:$<CONFIG>>/)
 
 ###-------------------------------------------------------------------------------------
 # Copy dependencies needed for running tests.

--- a/tests/TestReadMask.c
+++ b/tests/TestReadMask.c
@@ -51,7 +51,7 @@ product endorsement purposes.
 */
 #include <stdio.h>
 #include <silo.h>
-#ifndef WIN32
+#ifndef _WIN32
 #include <sys/time.h>
 #else
 #include <string.h>

--- a/tests/dir.c
+++ b/tests/dir.c
@@ -51,7 +51,7 @@ herein do not necessarily state  or reflect those of the United States
 Government or Lawrence Livermore National Security, LLC, and shall not
 be used for advertising or product endorsement purposes.
 */
-#ifndef WIN32
+#ifndef _WIN32
 #include <unistd.h>
 #else
 #include <direct.h>
@@ -298,7 +298,7 @@ int main(int argc, char *argv[])
     /* test attempt to DBCreate a file without clobbering it and
        for which the path is really a dir in the host filesystem */
     unlink("dir-test-foo");
-#ifndef WIN32
+#ifndef _WIN32
     mkdir("dir-test-foo", 0777);
 #else
     mkdir("dir-test-foo");
@@ -307,7 +307,7 @@ int main(int argc, char *argv[])
     unlink("dir-test-foo");
     if (dbfile2 != 0)
         exit(EXIT_FAILURE);
-#ifndef WIN32
+#ifndef _WIN32
     mkdir("dir-test-foo", 0777);
 #else
     mkdir("dir-test-foo");

--- a/tests/grab.c
+++ b/tests/grab.c
@@ -56,7 +56,7 @@ be used for advertising or product endorsement purposes.
 #include <string.h>
 #include <sys/types.h>
 #include <sys/stat.h>
-#ifndef WIN32
+#ifndef _WIN32
 #include <sys/time.h>
 #include <unistd.h>
 #endif

--- a/tests/largefile.c
+++ b/tests/largefile.c
@@ -54,14 +54,14 @@ be used for advertising or product endorsement purposes.
 
 #include "silo.h"               /*include public silo           */
 
-#ifdef WIN32
+#ifdef _WIN32
 #include <stdlib.h>
 #endif
 #include <math.h>
 #include <string.h>
 #include <sys/types.h>
 #include <sys/stat.h>
-#ifndef WIN32
+#ifndef _WIN32
 #include <unistd.h>
 #endif
 

--- a/tests/largefile_netcdf.c
+++ b/tests/largefile_netcdf.c
@@ -1,14 +1,14 @@
 #include <netcdf.h>
 #include <stdio.h>
 
-#ifdef WIN32
+#ifdef _WIN32
 #include <stdlib.h>
 #endif
 #include <math.h>
 #include <string.h>
 #include <sys/types.h>
 #include <sys/stat.h>
-#ifndef WIN32
+#ifndef _WIN32
 #include <unistd.h>
 #endif
 

--- a/tests/merge_block.c
+++ b/tests/merge_block.c
@@ -55,7 +55,7 @@ product endorsement purposes.
 #include <silo.h>
 #include <sys/stat.h>
 #include <sys/types.h>
-#ifndef WIN32
+#ifndef _WIN32
 #include <dirent.h>
 #include <unistd.h>
 #else
@@ -713,7 +713,7 @@ GetFileList (char *baseName, char ***filesOut, int *nFilesOut)
     int       nFileMax;
     char    **files=NULL;
 
-#ifndef WIN32
+#ifndef _WIN32
     DIR      *dirp=NULL;
     struct dirent  *dp=NULL;
 #else
@@ -727,7 +727,7 @@ GetFileList (char *baseName, char ***filesOut, int *nFilesOut)
     /*
      * Open the directory.
      */
-#ifndef WIN32
+#ifndef _WIN32
     dirp = opendir (".");
     if (dirp == NULL) {
         printf ("Error opening current directory\n");
@@ -754,7 +754,7 @@ GetFileList (char *baseName, char ***filesOut, int *nFilesOut)
     nFiles = 0;
     nFileMax = 128;
     files = ALLOC_N (char *, nFileMax);
-#ifndef WIN32
+#ifndef _WIN32
     for (dp = readdir (dirp); dp != NULL; dp = readdir (dirp))
     {
         char *fName = dp->d_name;
@@ -790,7 +790,7 @@ GetFileList (char *baseName, char ***filesOut, int *nFilesOut)
     /*
      * Close the directory.
      */
-#ifndef WIN32
+#ifndef _WIN32
     closedir (dirp);
 #else
     FindClose(dirHandle);

--- a/tests/misc.c
+++ b/tests/misc.c
@@ -67,7 +67,7 @@ be used for advertising or product endorsement purposes.
 #include <hdf5.h>
 #endif
 
-#ifdef WIN32
+#ifdef _WIN32
 #include <string.h>
 #endif
 

--- a/tests/multi_file.c
+++ b/tests/multi_file.c
@@ -62,7 +62,7 @@ product endorsement purposes.
 #include <sys/stat.h>
 #include <sys/types.h>
 
-#ifdef WIN32
+#ifdef _WIN32
 #  include <direct.h>
 #else
 #  include <unistd.h>

--- a/tests/multi_file_memfile.c
+++ b/tests/multi_file_memfile.c
@@ -62,7 +62,7 @@ product endorsement purposes.
 #include <sys/stat.h>
 #include <sys/types.h>
 
-#ifdef WIN32
+#ifdef _WIN32
 #  include <direct.h>
 #else
 #  include <unistd.h>

--- a/tests/obj.c
+++ b/tests/obj.c
@@ -55,7 +55,7 @@ be used for advertising or product endorsement purposes.
 #include "silo.h"
 #include <math.h>
 #include <stdlib.h>
-#ifdef WIN32
+#ifdef _WIN32
 #include <string.h>
 #endif
 #include <std.c>

--- a/tests/partial_io.c
+++ b/tests/partial_io.c
@@ -55,7 +55,7 @@ product endorsement purposes.
 #include <stdlib.h>     /* For abort() */
 #include <std.c>
 
-#ifdef WIN32
+#ifdef _WIN32
 #define strtok_r(s,sep,lasts) (*(lasts)=strtok((s),(sep)))
 #endif
 

--- a/tests/point.c
+++ b/tests/point.c
@@ -55,7 +55,7 @@ be used for advertising or product endorsement purposes.
 #include "silo.h"
 #include <math.h>
 #include <stdlib.h>
-#ifdef WIN32
+#ifdef _WIN32
 #include <string.h>
 #endif
 #include <std.c>

--- a/tests/sami.c
+++ b/tests/sami.c
@@ -67,7 +67,7 @@ be used for advertising or product endorsement purposes.
 #include <hdf5.h>
 #endif
 
-#ifdef WIN32
+#ifdef _WIN32
 #include <string.h>
 #endif
 

--- a/tests/simple.c
+++ b/tests/simple.c
@@ -57,7 +57,7 @@ be used for advertising or product endorsement purposes.
 #include <math.h>
 #include <stdlib.h>
 #include <string.h>
-#ifndef WIN32
+#ifndef _WIN32
 #include <unistd.h>
 #endif
 

--- a/tests/testall.c
+++ b/tests/testall.c
@@ -80,7 +80,7 @@ be used for advertising or product endorsement purposes.
 
 #include <math.h>
 #include <stdlib.h>
-#ifndef WIN32
+#ifndef _WIN32
 #include <unistd.h>
 #else
 #include <stdio.h>
@@ -1636,7 +1636,7 @@ build_rect3d(DBfile * dbfile, int size, int order)
 
     DBPutQuadmesh(dbfile, meshname, NULL, coords, dims, ndims, DB_FLOAT,
                   DB_COLLINEAR, optlist);
-#ifndef WIN32
+#ifndef _WIN32
     binf = open("rect3dz.bin", O_CREAT|O_TRUNC|O_WRONLY, S_IRUSR|S_IWUSR);
 #else
     binf = open("rect3dz.bin", O_CREAT|O_TRUNC|O_WRONLY, S_IREAD|S_IWRITE);
@@ -1653,7 +1653,7 @@ build_rect3d(DBfile * dbfile, int size, int order)
     close(binf);
     printf("zsize = nz=%d, ny=%d, nx=%d\n", zdims[2], zdims[1], zdims[0]);
 
-#ifndef WIN32
+#ifndef _WIN32
     binf = open("rect3dn.bin", O_CREAT|O_TRUNC|O_WRONLY, S_IRUSR|S_IWUSR);
 #else
     binf = open("rect3dn.bin", O_CREAT|O_TRUNC|O_WRONLY, S_IREAD|S_IWRITE);

--- a/tests/testfs.c
+++ b/tests/testfs.c
@@ -51,7 +51,7 @@ herein do not necessarily state  or reflect those of the United States
 Government or Lawrence Livermore National Security, LLC, and shall not
 be used for advertising or product endorsement purposes.
 */
-#ifndef WIN32
+#ifndef _WIN32
 #include <unistd.h>
 #else
 #include <direct.h>

--- a/tools/python/CMakeLists.txt
+++ b/tools/python/CMakeLists.txt
@@ -97,15 +97,7 @@ install(FILES s2ex.py DESTINATION bin
         PERMISSIONS OWNER_READ OWNER_WRITE
                     GROUP_READ GROUP_WRITE
                     WORLD_READ)
-if(WIN32)
-    add_custom_command(TARGET Silo POST_BUILD
-            COMMAND ${CMAKE_COMMAND} -E copy_if_different
-            ${CMAKE_CURRENT_SOURCE_DIR}/s2ex.py
-            ${Silo_BINARY_DIR}/bin/$<CONFIG>)
-else()
-    add_custom_command(TARGET Silo POST_BUILD
-            COMMAND ${CMAKE_COMMAND} -E copy_if_different
-            ${CMAKE_CURRENT_SOURCE_DIR}/s2ex.py
-            ${Silo_BINARY_DIR}/bin/)
-endif()
-
+add_custom_command(TARGET Silo POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different
+        ${CMAKE_CURRENT_SOURCE_DIR}/s2ex.py
+        ${Silo_BINARY_DIR}/bin/$<$<BOOL:${is_multi_config}>:$<CONFIG>>/)

--- a/tools/silex/CMakeLists.txt
+++ b/tools/silex/CMakeLists.txt
@@ -117,8 +117,8 @@ if(WIN32 AND TARGET Qt5::windeployqt)
         POST_BUILD
         COMMAND ${CMAKE_COMMAND} -E remove_directory "${CMAKE_CURRENT_BINARY_DIR}/windeployqt"
         COMMAND set PATH=%PATH%$<SEMICOLON>${qt5_install_prefix}/bin
-        COMMAND Qt5::windeployqt --dir "${CMAKE_CURRENT_BINARY_DIR}/windeployqt" "$<TARGET_FILE_DIR:silex>/$<TARGET_FILE_NAME:silex>"
-        COMMAND Qt5::windeployqt --verbose 0 --dir "${Silo_BINARY_DIR}/bin/$<CONFIG>" "$<TARGET_FILE_DIR:silex>/$<TARGET_FILE_NAME:silex>"
+        COMMAND Qt5::windeployqt --dir "${CMAKE_CURRENT_BINARY_DIR}/windeployqt" "$<TARGET_FILE:silex>"
+        COMMAND Qt5::windeployqt --verbose 0 --dir "${Silo_BINARY_DIR}/bin/$<CONFIG>" "$<TARGET_FILE:silex>"
     )
 
     # copy deployment directory during installation


### PR DESCRIPTION
---
A variety of fixes that separates the "Windows is Visual Studio" assumptions, fix a few other technicalities I encountered along the way, and some simplifications.

The `_MSC_VER` patch has a trivial contextual conflict with 4.11RC, but the rest may be helpful there if wanted.