### PR TITLE
tests: add missing header for `difftime`

### DIFF
--- a/tests/TestReadMask.c
+++ b/tests/TestReadMask.c
@@ -49,6 +49,7 @@ reflect those  of the United  States Government or  Lawrence Livermore
 National  Security, LLC,  and shall  not  be used  for advertising  or
 product endorsement purposes.
 */
+
 #include <stdio.h>
 #include <silo.h>
 #include <string.h>

--- a/tests/TestReadMask.c
+++ b/tests/TestReadMask.c
@@ -51,13 +51,12 @@ product endorsement purposes.
 */
 #include <stdio.h>
 #include <silo.h>
+#include <string.h>
 #ifndef _WIN32
 #include <sys/time.h>
-#else
-#include <string.h>
-#include <time.h>
 #endif
 #include <sys/timeb.h>
+#include <time.h>
 #include <std.c>
 
 /* To compile this program on hyper, here is the command:

--- a/tests/TestReadMask.c
+++ b/tests/TestReadMask.c
@@ -49,7 +49,6 @@ reflect those  of the United  States Government or  Lawrence Livermore
 National  Security, LLC,  and shall  not  be used  for advertising  or
 product endorsement purposes.
 */
-
 #include <stdio.h>
 #include <silo.h>
 #include <string.h>


### PR DESCRIPTION
With GCC 14, which makes implicit function declarations an error by default:
```
TestReadMask.c: In function ‘ElapsedTime’:
TestReadMask.c:746:15: error: implicit declaration of function ‘difftime’ [-Wimplicit-function-declaration]
  746 |     ms = (int)difftime(end_time.tv_sec, start_time.tv_sec);
      |               ^~~~~~~~
TestReadMask.c:62:1: note: ‘difftime’ is defined in header ‘<time.h>’; this is probably fixable by adding ‘#include <time.h>’
   61 | #include <std.c>
  +++ |+#include <time.h>
   62 |
```

Fix the include guards and include <time.h> unconditionally (for difftime) and <string.h> unconditionally too (for memcpy).