### PR TITLE
Fix dir on dbtoc

### DIFF
--- a/src/silo/silo_ns.c
+++ b/src/silo/silo_ns.c
@@ -49,6 +49,7 @@ reflect those  of the United  States Government or  Lawrence Livermore
 National  Security, LLC,  and shall  not  be used  for advertising  or
 product endorsement purposes.
 */
+#include <ctype.h>
 #include <stdarg.h>
 #include <stdlib.h>
 #include <errno.h>


### PR DESCRIPTION
Fix #372 so that `dir()` on a `DBtoc` object works as expected. Also, fix missing header file.