### PR TITLE
Unify python objects between hdf5 and pdb drivers

### DIFF
--- a/src/hdf5_drv/silo_hdf5.c
+++ b/src/hdf5_drv/silo_hdf5.c
@@ -8762,18 +8762,7 @@ db_hdf5_GetObject(DBfile *_dbfile, char const *name)
                                   H5T_NATIVE_INT);
                 memcpy(mem_value, file_value, H5Tget_size(atype));
                 H5Tconvert(atype, mtype, 1, mem_value, bkg, H5P_DEFAULT);
-#if 0
                 DBAddIntNComponent(obj, name, nelmts, (int*)mem_value);
-#else
-                if (1==nelmts) {
-                    DBAddIntComponent(obj, name, *((int*)mem_value));
-                } else {
-                    for (j=0; (size_t)j<nelmts; j++) {
-                        sprintf(bigname, "%s%d", name, j+1);
-                        DBAddIntComponent(obj, bigname, ((int*)mem_value)[j]);
-                    }
-                }
-#endif
                 break;
 
             case H5T_FLOAT:
@@ -8783,35 +8772,11 @@ db_hdf5_GetObject(DBfile *_dbfile, char const *name)
                 H5Tconvert(atype, mtype, 1, mem_value, bkg, H5P_DEFAULT);
                 if (4 == (int) H5Tget_size(member_type))
                 {
-#if 0
                     DBAddFltNComponent(obj, name, nelmts, (double*)mem_value);
-#else
-                    if (1==nelmts) {
-                        DBAddFltComponent(obj, name, *((double*)mem_value));
-                    } else {
-                        for (j=0; (size_t)j<nelmts; j++) {
-                            sprintf(bigname, "%s%d", name, j+1);
-                            DBAddFltComponent(obj, bigname,
-                                              ((double*)mem_value)[j]);
-                        }
-                    }
-#endif
                 }
                 else
                 {
-#if 0
                     DBAddDblNComponent(obj, name, nelmts, (double*)mem_value);
-#else
-                    if (1==nelmts) {
-                        DBAddDblComponent(obj, name, *((double*)mem_value));
-                    } else {
-                        for (j=0; (size_t)j<nelmts; j++) {
-                            sprintf(bigname, "%s%d", name, j+1);
-                            DBAddDblComponent(obj, bigname,
-                                              ((double*)mem_value)[j]);
-                        }
-                    }
-#endif
                 }
                 break;
 

--- a/src/hdf5_drv/silo_hdf5.c
+++ b/src/hdf5_drv/silo_hdf5.c
@@ -7097,10 +7097,10 @@ db_hdf5_GetComponentStuff(DBfile *_dbfile, char const *objname, char const *comp
                 UNWIND();
             }
 
+            for (i=0, mult=1; i<ndims; i++) mult *= dim[i];
+
             if (just_get_datatype == 0)
             {
-                for (i=0, mult=1; i<ndims; i++) mult *= dim[i];
-
                 /* Allocate the return value */
                 if (NULL==(retval=calloc(mult, db_GetMachDataSize(datatype)))) {
                     db_perror(compname, E_CALLFAIL, me);
@@ -7138,6 +7138,15 @@ db_hdf5_GetComponentStuff(DBfile *_dbfile, char const *objname, char const *comp
             else
             {
                 *just_get_datatype = datatype;
+                if (mult > 1)
+                {
+                    if (datatype == DB_INT)
+                        *just_get_datatype = DB_INTA;
+                    else if (datatype == DB_FLOAT)
+                        *just_get_datatype = DB_FLOATA;
+                    else if (datatype == DB_DOUBLE)
+                        *just_get_datatype = DB_DOUBLEA;
+                }
             }
         }
         

--- a/src/silo/silo.c
+++ b/src/silo/silo.c
@@ -3269,7 +3269,7 @@ DBAddIntNComponent(DBobject *object, const char *compname, int n, int const *ii)
     int            i;
     char           tmp[256];
 
-    API_BEGIN("DBAddIntComponent", int, -1) {
+    API_BEGIN("DBAddIntNComponent", int, -1) {
         if (!object)
             API_ERROR("object pointer", E_BADARGS);
         if (!compname || !*compname)
@@ -3353,7 +3353,7 @@ DBAddFltNComponent(DBobject *object, const char *compname, int n, double const *
     int            i;
     char           tmp[256];
 
-    API_BEGIN("DBAddFltComponent", int, -1) {
+    API_BEGIN("DBAddFltNComponent", int, -1) {
         if (!object)
             API_ERROR("object pointer", E_BADARGS);
         if (!compname || !*compname)
@@ -3373,6 +3373,7 @@ DBAddFltNComponent(DBobject *object, const char *compname, int n, double const *
         {
             char tmp2[32];
             snprintf(tmp2, sizeof(tmp2), ",%g", ff[i]);
+            strcat(tmp, tmp2);
         }
         strcat(tmp, "'");
 
@@ -3422,7 +3423,7 @@ DBAddDblNComponent(DBobject *object, const char *compname, int n, double const *
     int            i;
     char           tmp[256];
 
-    API_BEGIN("DBAddDblComponent", int, -1) {
+    API_BEGIN("DBAddDblNComponent", int, -1) {
         if (!object)
             API_ERROR("object pointer", E_BADARGS);
         if (!compname || !*compname)
@@ -3442,6 +3443,7 @@ DBAddDblNComponent(DBobject *object, const char *compname, int n, double const *
         {
             char tmp2[64];
             snprintf(tmp2, sizeof(tmp2), ",%.30g", dd[i]);
+            strcat(tmp,tmp2);
         }
         strcat(tmp, "'");
 

--- a/src/silo/silo.h.in
+++ b/src/silo/silo.h.in
@@ -357,7 +357,13 @@ typedef enum {
     DB_DOUBLE=20,
     DB_CHAR=21,
     DB_LONG_LONG=22,
-    DB_NOTYPE=25           /*unknown type */
+
+    /* mini-array types for things like dims[3] or min_extents[3] */
+    DB_INTA=23,
+    DB_FLOATA=24,
+    DB_DOUBLEA=25,
+
+    DB_NOTYPE=26           /*unknown type */
 } DBdatatype;
 
 /* Flags for DBCreate */

--- a/tools/python/pydbfile.cpp
+++ b/tools/python/pydbfile.cpp
@@ -383,9 +383,13 @@ static PyObject *DBfile_DBGetVarInfo(PyObject *self, PyObject *args)
                 int len = pdbname.length();
                 valStr = string((const char*)(pdbname.c_str()),4,len-5);
             }
-            if (get_data_flag)
+            bool is_meta_data = false;
+            if ((compname == "align") || (compname == "baseindex") || (compname == "dims") ||
+                (compname == "dtime") || (compname == "max_extents") || (compname == "max_index") ||
+                (compname == "min_extents") || (compname == "min_index") || (compname == "time"))
+                is_meta_data = true;
+            if (get_data_flag || is_meta_data)
             {
-
                 PyObject *argTuple = PyTuple_New(2);
                 PyTuple_SET_ITEM(argTuple, 0, PyString_FromString(valStr.c_str()));
                 PyTuple_SET_ITEM(argTuple, 1, PyString_FromString("dont-throw-errors-in-sanity-checks"));

--- a/tools/python/pydbfile.cpp
+++ b/tools/python/pydbfile.cpp
@@ -322,50 +322,40 @@ static PyObject *DBfile_DBGetVarInfo(PyObject *self, PyObject *args)
                 continue;
             }
         }
-        string typestr = "";
         int ival = -1;
         switch (type)
         {
           case DB_INT:
-            typestr = "int";
             ival = *((int*)comp);
             PyDict_SetItemString(retval, compname.c_str(), PyInt_FromLong((long)ival));
             break;
           case DB_SHORT:
-            typestr = "short";
             ival = *((short*)comp);
             PyDict_SetItemString(retval, compname.c_str(), PyInt_FromLong((long)ival));
             break;
           case DB_LONG:
-            typestr = "long";
             ival = (int) *((long*)comp);
             PyDict_SetItemString(retval, compname.c_str(), PyInt_FromLong((long)ival));
             break;
           case DB_LONG_LONG:
-            typestr = "long long";
             ival = (int) *((long long*)comp);
             PyDict_SetItemString(retval, compname.c_str(), PyInt_FromLong((long)ival));
             break;
           case DB_FLOAT:
-            typestr = "float";
             PyDict_SetItemString(retval, compname.c_str(), PyFloat_FromDouble((double)*((float*)comp)));
             break;
           case DB_DOUBLE:
-            typestr = "double";
             PyDict_SetItemString(retval, compname.c_str(), PyFloat_FromDouble(*((double*)comp)));
             break;
           case DB_CHAR:
-            typestr = "char";
             if (*((char*)comp)== 0)
                 PyDict_SetItemString(retval, compname.c_str(), PyString_FromString(""));
             else
                 PyDict_SetItemString(retval, compname.c_str(), PyString_FromString((char*)comp));
             break;
           case DB_NOTYPE:
-            typestr = "notype";
             break;
           default:
-            typestr = "var";
             string valStr = std::string(pdbname.c_str());
             if (pdbname.find("'<s>") == 0)
             {

--- a/tools/python/pydbfile.cpp
+++ b/tools/python/pydbfile.cpp
@@ -305,13 +305,13 @@ static PyObject *DBfile_DBGetVarInfo(PyObject *self, PyObject *args)
     PyDict_SetItemString(retval, "type", PyString_FromString(silo_obj->type));
     for (int i=0; i<silo_obj->ncomponents; i++)
     {
+        PyObject *tmpTuple;
         string compname = silo_obj->comp_names[i];
         string pdbname  = silo_obj->pdb_names[i];
         int type = DBGetComponentType(db, str, compname.c_str());
         void *comp = 0;
 
-        if (type == DB_INT || type == DB_SHORT || type == DB_LONG || type == DB_LONG_LONG ||
-            type == DB_FLOAT || type == DB_DOUBLE || type == DB_CHAR)
+        if (type != DB_NOTYPE)
         {
             comp  = DBGetComponent(db, str, compname.c_str());
             if (!comp)
@@ -329,6 +329,13 @@ static PyObject *DBfile_DBGetVarInfo(PyObject *self, PyObject *args)
             ival = *((int*)comp);
             PyDict_SetItemString(retval, compname.c_str(), PyInt_FromLong((long)ival));
             break;
+          case DB_INTA:
+            tmpTuple = PyTuple_New(3);
+            PyTuple_SET_ITEM(tmpTuple, 0, PyInt_FromLong((long)((int*)comp)[0]));
+            PyTuple_SET_ITEM(tmpTuple, 1, PyInt_FromLong((long)((int*)comp)[1]));
+            PyTuple_SET_ITEM(tmpTuple, 2, PyInt_FromLong((long)((int*)comp)[2]));
+            PyDict_SetItemString(retval, compname.c_str(), tmpTuple);
+            break;
           case DB_SHORT:
             ival = *((short*)comp);
             PyDict_SetItemString(retval, compname.c_str(), PyInt_FromLong((long)ival));
@@ -344,8 +351,22 @@ static PyObject *DBfile_DBGetVarInfo(PyObject *self, PyObject *args)
           case DB_FLOAT:
             PyDict_SetItemString(retval, compname.c_str(), PyFloat_FromDouble((double)*((float*)comp)));
             break;
+          case DB_FLOATA:
+            tmpTuple = PyTuple_New(3);
+            PyTuple_SET_ITEM(tmpTuple, 0, PyFloat_FromDouble((double)((float*)comp)[0]));
+            PyTuple_SET_ITEM(tmpTuple, 1, PyFloat_FromDouble((double)((float*)comp)[1]));
+            PyTuple_SET_ITEM(tmpTuple, 2, PyFloat_FromDouble((double)((float*)comp)[2]));
+            PyDict_SetItemString(retval, compname.c_str(), tmpTuple);
+            break;
           case DB_DOUBLE:
             PyDict_SetItemString(retval, compname.c_str(), PyFloat_FromDouble(*((double*)comp)));
+            break;
+          case DB_DOUBLEA:
+            tmpTuple = PyTuple_New(3);
+            PyTuple_SET_ITEM(tmpTuple, 0, PyFloat_FromDouble((double)((double*)comp)[0]));
+            PyTuple_SET_ITEM(tmpTuple, 1, PyFloat_FromDouble((double)((double*)comp)[1]));
+            PyTuple_SET_ITEM(tmpTuple, 2, PyFloat_FromDouble((double)((double*)comp)[2]));
+            PyDict_SetItemString(retval, compname.c_str(), tmpTuple);
             break;
           case DB_CHAR:
             if (*((char*)comp)== 0)


### PR DESCRIPTION
There are a number of oddities in pyhton objects primarily because python interface uses generic DBGetObject and iterating over components to do its work. The PDB and HDF5 drivers build their associated generic objects differently. 

This PR unifies a lot of this and there is still more to complete here.