### PR TITLE
Add consistency in  WIN32 define checks

### DIFF
--- a/src/silo/silo_win32_compatibility.h
+++ b/src/silo/silo_win32_compatibility.h
@@ -1,4 +1,4 @@
-#ifdef WIN32
+#ifdef _WIN32
 #ifndef SILO_WIN32_COMPATIBILITY
 #define SILO_WIN32_COMPATIBILITY
 #include <io.h>  /* Include Windows IO */

--- a/tests/TestReadMask.c
+++ b/tests/TestReadMask.c
@@ -51,7 +51,7 @@ product endorsement purposes.
 */
 #include <stdio.h>
 #include <silo.h>
-#ifndef WIN32
+#ifndef _WIN32
 #include <sys/time.h>
 #else
 #include <string.h>

--- a/tests/dir.c
+++ b/tests/dir.c
@@ -51,7 +51,7 @@ herein do not necessarily state  or reflect those of the United States
 Government or Lawrence Livermore National Security, LLC, and shall not
 be used for advertising or product endorsement purposes.
 */
-#ifndef WIN32
+#ifndef _WIN32
 #include <unistd.h>
 #else
 #include <direct.h>
@@ -298,7 +298,7 @@ int main(int argc, char *argv[])
     /* test attempt to DBCreate a file without clobbering it and
        for which the path is really a dir in the host filesystem */
     unlink("dir-test-foo");
-#ifndef WIN32
+#ifndef _WIN32
     mkdir("dir-test-foo", 0777);
 #else
     mkdir("dir-test-foo");
@@ -307,7 +307,7 @@ int main(int argc, char *argv[])
     unlink("dir-test-foo");
     if (dbfile2 != 0)
         exit(EXIT_FAILURE);
-#ifndef WIN32
+#ifndef _WIN32
     mkdir("dir-test-foo", 0777);
 #else
     mkdir("dir-test-foo");

--- a/tests/grab.c
+++ b/tests/grab.c
@@ -56,7 +56,7 @@ be used for advertising or product endorsement purposes.
 #include <string.h>
 #include <sys/types.h>
 #include <sys/stat.h>
-#ifndef WIN32
+#ifndef _WIN32
 #include <sys/time.h>
 #include <unistd.h>
 #endif

--- a/tests/largefile.c
+++ b/tests/largefile.c
@@ -54,14 +54,14 @@ be used for advertising or product endorsement purposes.
 
 #include "silo.h"               /*include public silo           */
 
-#ifdef WIN32
+#ifdef _WIN32
 #include <stdlib.h>
 #endif
 #include <math.h>
 #include <string.h>
 #include <sys/types.h>
 #include <sys/stat.h>
-#ifndef WIN32
+#ifndef _WIN32
 #include <unistd.h>
 #endif
 

--- a/tests/largefile_netcdf.c
+++ b/tests/largefile_netcdf.c
@@ -1,14 +1,14 @@
 #include <netcdf.h>
 #include <stdio.h>
 
-#ifdef WIN32
+#ifdef _WIN32
 #include <stdlib.h>
 #endif
 #include <math.h>
 #include <string.h>
 #include <sys/types.h>
 #include <sys/stat.h>
-#ifndef WIN32
+#ifndef _WIN32
 #include <unistd.h>
 #endif
 

--- a/tests/merge_block.c
+++ b/tests/merge_block.c
@@ -55,7 +55,7 @@ product endorsement purposes.
 #include <silo.h>
 #include <sys/stat.h>
 #include <sys/types.h>
-#ifndef WIN32
+#ifndef _WIN32
 #include <dirent.h>
 #include <unistd.h>
 #else
@@ -713,7 +713,7 @@ GetFileList (char *baseName, char ***filesOut, int *nFilesOut)
     int       nFileMax;
     char    **files=NULL;
 
-#ifndef WIN32
+#ifndef _WIN32
     DIR      *dirp=NULL;
     struct dirent  *dp=NULL;
 #else
@@ -727,7 +727,7 @@ GetFileList (char *baseName, char ***filesOut, int *nFilesOut)
     /*
      * Open the directory.
      */
-#ifndef WIN32
+#ifndef _WIN32
     dirp = opendir (".");
     if (dirp == NULL) {
         printf ("Error opening current directory\n");
@@ -754,7 +754,7 @@ GetFileList (char *baseName, char ***filesOut, int *nFilesOut)
     nFiles = 0;
     nFileMax = 128;
     files = ALLOC_N (char *, nFileMax);
-#ifndef WIN32
+#ifndef _WIN32
     for (dp = readdir (dirp); dp != NULL; dp = readdir (dirp))
     {
         char *fName = dp->d_name;
@@ -790,7 +790,7 @@ GetFileList (char *baseName, char ***filesOut, int *nFilesOut)
     /*
      * Close the directory.
      */
-#ifndef WIN32
+#ifndef _WIN32
     closedir (dirp);
 #else
     FindClose(dirHandle);

--- a/tests/misc.c
+++ b/tests/misc.c
@@ -67,7 +67,7 @@ be used for advertising or product endorsement purposes.
 #include <hdf5.h>
 #endif
 
-#ifdef WIN32
+#ifdef _WIN32
 #include <string.h>
 #endif
 

--- a/tests/multi_file.c
+++ b/tests/multi_file.c
@@ -62,7 +62,7 @@ product endorsement purposes.
 #include <sys/stat.h>
 #include <sys/types.h>
 
-#ifdef WIN32
+#ifdef _WIN32
 #  include <direct.h>
 #else
 #  include <unistd.h>

--- a/tests/multi_file_memfile.c
+++ b/tests/multi_file_memfile.c
@@ -62,7 +62,7 @@ product endorsement purposes.
 #include <sys/stat.h>
 #include <sys/types.h>
 
-#ifdef WIN32
+#ifdef _WIN32
 #  include <direct.h>
 #else
 #  include <unistd.h>

--- a/tests/obj.c
+++ b/tests/obj.c
@@ -55,7 +55,7 @@ be used for advertising or product endorsement purposes.
 #include "silo.h"
 #include <math.h>
 #include <stdlib.h>
-#ifdef WIN32
+#ifdef _WIN32
 #include <string.h>
 #endif
 #include <std.c>

--- a/tests/partial_io.c
+++ b/tests/partial_io.c
@@ -55,7 +55,7 @@ product endorsement purposes.
 #include <stdlib.h>     /* For abort() */
 #include <std.c>
 
-#ifdef WIN32
+#ifdef _WIN32
 #define strtok_r(s,sep,lasts) (*(lasts)=strtok((s),(sep)))
 #endif
 

--- a/tests/point.c
+++ b/tests/point.c
@@ -55,7 +55,7 @@ be used for advertising or product endorsement purposes.
 #include "silo.h"
 #include <math.h>
 #include <stdlib.h>
-#ifdef WIN32
+#ifdef _WIN32
 #include <string.h>
 #endif
 #include <std.c>

--- a/tests/sami.c
+++ b/tests/sami.c
@@ -67,7 +67,7 @@ be used for advertising or product endorsement purposes.
 #include <hdf5.h>
 #endif
 
-#ifdef WIN32
+#ifdef _WIN32
 #include <string.h>
 #endif
 

--- a/tests/simple.c
+++ b/tests/simple.c
@@ -57,7 +57,7 @@ be used for advertising or product endorsement purposes.
 #include <math.h>
 #include <stdlib.h>
 #include <string.h>
-#ifndef WIN32
+#ifndef _WIN32
 #include <unistd.h>
 #endif
 

--- a/tests/testall.c
+++ b/tests/testall.c
@@ -80,7 +80,7 @@ be used for advertising or product endorsement purposes.
 
 #include <math.h>
 #include <stdlib.h>
-#ifndef WIN32
+#ifndef _WIN32
 #include <unistd.h>
 #else
 #include <stdio.h>
@@ -1636,7 +1636,7 @@ build_rect3d(DBfile * dbfile, int size, int order)
 
     DBPutQuadmesh(dbfile, meshname, NULL, coords, dims, ndims, DB_FLOAT,
                   DB_COLLINEAR, optlist);
-#ifndef WIN32
+#ifndef _WIN32
     binf = open("rect3dz.bin", O_CREAT|O_TRUNC|O_WRONLY, S_IRUSR|S_IWUSR);
 #else
     binf = open("rect3dz.bin", O_CREAT|O_TRUNC|O_WRONLY, S_IREAD|S_IWRITE);
@@ -1653,7 +1653,7 @@ build_rect3d(DBfile * dbfile, int size, int order)
     close(binf);
     printf("zsize = nz=%d, ny=%d, nx=%d\n", zdims[2], zdims[1], zdims[0]);
 
-#ifndef WIN32
+#ifndef _WIN32
     binf = open("rect3dn.bin", O_CREAT|O_TRUNC|O_WRONLY, S_IRUSR|S_IWUSR);
 #else
     binf = open("rect3dn.bin", O_CREAT|O_TRUNC|O_WRONLY, S_IREAD|S_IWRITE);

--- a/tests/testfs.c
+++ b/tests/testfs.c
@@ -51,7 +51,7 @@ herein do not necessarily state  or reflect those of the United States
 Government or Lawrence Livermore National Security, LLC, and shall not
 be used for advertising or product endorsement purposes.
 */
-#ifndef WIN32
+#ifndef _WIN32
 #include <unistd.h>
 #else
 #include <direct.h>

--- a/tools/python/pysilo.cpp
+++ b/tools/python/pysilo.cpp
@@ -68,7 +68,7 @@ static PyObject             *siloModule = 0;
 std::vector<PyMethodDef> SiloMethods;
 
 #if defined(_WIN32)
-# if defined(Silo_EXPORTS)
+# if defined(SiloPy_EXPORTS) || defined(Silo_EXPORTS)
 #  define SILOMODULE_API __declspec(dllexport)
 # else
 #  define SILOMODULE_API __declspec(dllimport)


### PR DESCRIPTION
Use `_WIN32` instead of `WIN32` in the `#ifdef`  and `#if defined` checks.
The former is defined by the compiler, the latter only by the IDE.

Resolves #383.