### PR TITLE
Update python testing on Windows.

### DIFF
--- a/CMake/SiloFindHDF5.cmake
+++ b/CMake/SiloFindHDF5.cmake
@@ -73,16 +73,19 @@ if(HDF5_FOUND)
 
     # On Windows need to have hdf5's dll installed with browser/silex
     # in order for the executables to work
-    if(WIN32 AND (SILO_ENABLE_SILEX OR SILEX_ENABLE_BROWSER))
+    if(WIN32)
+        # DLL may also be needed by testing infrastructure
         get_target_property(HDF5_DLL ${HDF5_C_LIBRARIES} IMPORTED_LOCATION_RELEASE )
-        install(FILES ${HDF5_DLL} DESTINATION bin
-                PERMISSIONS OWNER_READ OWNER_WRITE
-                            GROUP_READ GROUP_WRITE
-                            WORLD_READ)
+        if(SILO_ENABLE_SILEX OR SILO_ENABLE_BROWSER)
+            install(FILES ${HDF5_DLL} DESTINATION bin
+                    PERMISSIONS OWNER_READ OWNER_WRITE
+                                GROUP_READ GROUP_WRITE
+                                WORLD_READ)
 
-        add_custom_command(TARGET copy_deps POST_BUILD
-             COMMAND ${CMAKE_COMMAND} -E copy_if_different
-             ${HDF5_DLL} ${Silo_BINARY_DIR}/bin/$<CONFIG>)
+            add_custom_command(TARGET copy_deps POST_BUILD
+                 COMMAND ${CMAKE_COMMAND} -E copy_if_different
+                 ${HDF5_DLL} ${Silo_BINARY_DIR}/bin/$<CONFIG>)
+        endif()
     endif()
 
 else()

--- a/CMake/SiloFindPython.cmake
+++ b/CMake/SiloFindPython.cmake
@@ -66,6 +66,17 @@ endif()
 find_package(Python COMPONENTS Interpreter Development)
 
 if(Python_FOUND)
+    if(WIN32)
+        # Need to ensure these vars are available by testing, so make
+        # them live in PARENT_SCOPE.
+        set(Python_EXECUTABLE ${Python_EXECUTABLE} PARENT_SCOPE)
+        if(TARGET Python::Module)
+            get_target_property(PYTHON_DLL Python::Module IMPORTED_LOCATION)
+            if(PYTHON_DLL)
+                set(PYTHON_DLL ${PYTHON_DLL} PARENT_SCOPE)
+            endif()
+        endif()
+    endif()
 else()
     message(FATAL_ERROR "An explicit request for Silo's python module was made but python could not be found. You may want to try setting SILO_PYTHON_DIR")
 endif()

--- a/CMake/SiloFindSzip.cmake
+++ b/CMake/SiloFindSzip.cmake
@@ -61,7 +61,7 @@
 
 if(DEFINED SILO_HDF5_SZIP_DIR AND EXISTS ${SILO_HDF5_SZIP_DIR}/szip-config.cmake)
     # this works for szip with CMake
-    find_package(SZIP PATHS ${SILO_HDF5_SZIP_DIR} CONFIG)
+    find_package(SZIP PATHS ${SILO_HDF5_SZIP_DIR} CONFIG NO_DEFAULT_PATH)
 else()
     if(DEFINED SILO_HDF5_SZIP_DIR AND EXISTS ${SILO_HDF5_SZIP_DIR})
         # help CMake find the specified szip
@@ -73,17 +73,18 @@ endif()
 if(SZIP_FOUND)
     # needed for config.h
     set(HAVE_LIBSZ 1)
-    if(WIN32 AND (SILO_ENABLE_SILEX OR SILEX_ENABLE_BROWSER))
+    if(WIN32)
         get_target_property(SZIP_DLL szip IMPORTED_LOCATION_RELEASE )
-        install(FILES ${SZIP_DLL} DESTINATION bin
-                PERMISSIONS OWNER_READ OWNER_WRITE
-                            GROUP_READ GROUP_WRITE
-                            WORLD_READ)
+        if(SILO_ENABLE_SILEX OR SILEX_ENABLE_BROWSER)
+            install(FILES ${SZIP_DLL} DESTINATION bin
+                    PERMISSIONS OWNER_READ OWNER_WRITE
+                                GROUP_READ GROUP_WRITE
+                                WORLD_READ)
 
-        add_custom_command(TARGET copy_deps POST_BUILD
-             COMMAND ${CMAKE_COMMAND} -E copy_if_different
-             ${SZIP_DLL} ${Silo_BINARY_DIR}/bin/$<CONFIG>)
-
+            add_custom_command(TARGET copy_deps POST_BUILD
+                 COMMAND ${CMAKE_COMMAND} -E copy_if_different
+                 ${SZIP_DLL} ${Silo_BINARY_DIR}/bin/$<CONFIG>)
+        endif()
     endif()
 else()
     message(FATAL_ERROR "Could not find szip, you may want to try setting SILO_HDF5_SZIP_DIR")

--- a/CMake/SiloFindZlib.cmake
+++ b/CMake/SiloFindZlib.cmake
@@ -74,17 +74,18 @@ if(ZLIB_FOUND)
     # needed for config.h
     set(HAVE_LIBZ 1)
     set(HAVE_ZLIB_H 1)
-    if(WIN32 AND (SILO_ENABLE_SILEX OR SILEX_ENABLE_BROWSER))
-        get_target_property(ZLIB_DLL zlib IMPORTED_LOCATION_RELEASE )
-        install(FILES ${ZLIB_DLL} DESTINATION bin
-                PERMISSIONS OWNER_READ OWNER_WRITE
-                            GROUP_READ GROUP_WRITE
-                            WORLD_READ)
+    if(WIN32)
+        get_target_property(ZLIB_DLL zlib IMPORTED_LOCATION_RELEASE)
+        if(SILO_ENABLE_SILEX OR SILEX_ENABLE_BROWSER)
+            install(FILES ${ZLIB_DLL} DESTINATION bin
+                    PERMISSIONS OWNER_READ OWNER_WRITE
+                                GROUP_READ GROUP_WRITE
+                                WORLD_READ)
 
-        add_custom_command(TARGET copy_deps POST_BUILD
-             COMMAND ${CMAKE_COMMAND} -E copy_if_different
-             ${ZLIB_DLL} ${Silo_BINARY_DIR}/bin/$<CONFIG>)
-
+            add_custom_command(TARGET copy_deps POST_BUILD
+                 COMMAND ${CMAKE_COMMAND} -E copy_if_different
+                 ${ZLIB_DLL} ${Silo_BINARY_DIR}/bin/$<CONFIG>)
+        endif()
     endif()
 else()
     message(FATAL_ERROR "Could not find zlib, you may want to try setting SILO_ZLIB_DIR")

--- a/config-site/steppenwolf.cmake
+++ b/config-site/steppenwolf.cmake
@@ -55,11 +55,12 @@
 ###
 # config-site for STEPPENWOLF, a Windows system.
 ###
+message("steppenwolf.cmake being processed")
 
 ###
 # Helpers for TP lib location
 ###
-set(TP_DIR C:/A_Visit/ForRegression/visit-deps/windowsbuild/MSVC2017)
+set(TP_DIR C:/A_Visit/ForRegression/visit-deps/windowsbuild/MSVC2022)
 
 ##
 # HDF5
@@ -69,25 +70,25 @@ silo_option_default(VAR SILO_HDF5_DIR VALUE ${TP_DIR}/hdf5/1.8.19)
 ##
 # SZIP
 ##
-silo_option_default(VAR SILO__HDF_SZIP_DIR VALUE ${TP_DIR}/szip/2.1.1/cmake)
+silo_option_default(VAR SILO_HDF5_SZIP_DIR VALUE ${TP_DIR}/szip/2.1.1/cmake)
 
 ##
 # ZLIB
 ##
-silo_option_default(VAR SILO_ZLIB_DIR VALUE ${TP_DIR}/zlib/1.2.11/cmake)
+silo_option_default(VAR SILO_ZLIB_DIR VALUE ${TP_DIR}/zlib/1.2.13/cmake)
 
 ##
 # QT5 (must be the location of Qt5Config.cmake)
 ##
-silo_option_default(VAR SILO_QT5_DIR VALUE ${TP_DIR}/Qt/5.14.2/lib/cmake/Qt5)
+#silo_option_default(VAR SILO_QT5_DIR VALUE ${TP_DIR}/Qt/5.14.2/lib/cmake/Qt5)
 
 ##
 # python
 ##
-silo_option_default(VAR SILO_PYTHON_DIR VALUE ${TP_DIR}/python/3.7.7)
+silo_option_default(VAR SILO_PYTHON_DIR VALUE ${TP_DIR}/python/3.9.18)
 
 # enable silex
-silo_option_default(VAR SILO_ENABLE_SILEX VALUE ON TYPE BOOL)
+#silo_option_default(VAR SILO_ENABLE_SILEX VALUE ON TYPE BOOL)
 
 # disable fortran
 silo_option_default(VAR SILO_ENABLE_FORTRAN VALUE OFF TYPE BOOL)
@@ -96,27 +97,6 @@ silo_option_default(VAR SILO_ENABLE_FORTRAN VALUE OFF TYPE BOOL)
 silo_option_default(VAR SILO_ENABLE_PYTHON_MODULE VALUE ON TYPE BOOL)
 
 # enable tests
-silo_option_default(VAR SILO_ENABLE_TESTS VALUE ON TYPE BOOL)
-
-
-
-# cmake automatically uses MDd for Debug flags, but the
-# third-party libs above are NOT debug versions, so won't be able to
-# link against them if that define is used.  Replace that flag:
-
-macro(silo_replace_flag OLD_FLAG NEW_FLAG FLAG_TYPE FLAG_STRING)
-    string(REPLACE "${OLD_FLAG}" "${NEW_FLAG}" TMP "${${FLAG_TYPE}}")
-    set(${FLAG_TYPE} "${TMP}" CACHE STRING "${FLAG_STRING}" FORCE)
-endmacro()
-
-# Change /MDd to /MD for debug builds
-silo_replace_flag("/MDd" "/MD" CMAKE_CXX_FLAGS_DEBUG
-             "Flags used by the compiler during debug builds")
-silo_replace_flag("/MDd" "/MD" CMAKE_C_FLAGS_DEBUG
-             "Flags used by the compiler during debug builds")
-silo_replace_flag("/MDd" "/MD" CMAKE_EXE_LINKER_FLAGS_DEBUG
-             "Flags used by the linker during debug builds")
-silo_replace_flag("/MDd" "/MD" CMAKE_MODULE_LINKER_FLAGS_DEBUG
-             "Flags used by the linker during debug builds")
+#silo_option_default(VAR SILO_ENABLE_TESTS VALUE ON TYPE BOOL)
 
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -99,10 +99,25 @@ if(WIN32)
              ${SZIP_DLL} ${silo_test_output_dir})
     endif()
 
+    # hdf5
     if(HDF5_FOUND AND DEFINED HDF5_DLL)
             add_custom_command(TARGET copy_test_deps POST_BUILD
                  COMMAND ${CMAKE_COMMAND} -E copy_if_different
                  ${HDF5_DLL} ${silo_test_output_dir})
+    endif()
+
+    # python
+    if(SILO_ENABLE_PYTHON_MODULE)
+      if(PYTHON_DLL)
+            add_custom_command(TARGET copy_test_deps POST_BUILD
+                 COMMAND ${CMAKE_COMMAND} -E copy_if_different
+                 ${PYTHON_DLL} ${silo_test_output_dir})
+      endif()
+      if(TARGET SiloPy)
+          add_custom_command(TARGET copy_test_deps POST_BUILD
+                     COMMAND ${CMAKE_COMMAND} -E copy_if_different
+                     $<TARGET_FILE:SiloPy> ${silo_test_output_dir})
+      endif()
     endif()
 
 endif()

--- a/tools/python/CMakeLists.txt
+++ b/tools/python/CMakeLists.txt
@@ -66,7 +66,7 @@ project(SiloPythonModule LANGUAGES CXX)
 # Python_add_library comes from CMake's FindPython package.
 # It automatically adds python includes/links to the target being created
 
-Python_add_library(Silo MODULE
+Python_add_library(SiloPy MODULE
     pydbfile.cpp
     pydbtoc.cpp
     pysilo.cpp)
@@ -79,16 +79,17 @@ else()
   set(mod_dest lib)
 endif()
 
-set_target_properties(Silo PROPERTIES
-                      LIBRARY_OUTPUT_DIRECTORY ${Silo_BINARY_DIR}/${mod_dest})
+set_target_properties(SiloPy PROPERTIES
+                      LIBRARY_OUTPUT_DIRECTORY ${Silo_BINARY_DIR}/${mod_dest}
+                      OUTPUT_NAME Silo)
 
-add_dependencies(Silo silo)
-target_link_libraries(Silo PRIVATE silo)
-target_include_directories(Silo PRIVATE
+add_dependencies(SiloPy silo)
+target_link_libraries(SiloPy PRIVATE silo)
+target_include_directories(SiloPy PRIVATE
      ${Silo_SOURCE_DIR}/src/silo
      ${silo_build_include_dir})
 
-install(TARGETS Silo DESTINATION ${mod_dest} EXPORT ${silo_targets_name}
+install(TARGETS SiloPy DESTINATION ${mod_dest} EXPORT ${silo_targets_name}
         PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE
                     GROUP_READ GROUP_WRITE GROUP_EXECUTE
                     WORLD_READ             WORLD_EXECUTE)
@@ -98,12 +99,12 @@ install(FILES s2ex.py DESTINATION bin
                     GROUP_READ GROUP_WRITE
                     WORLD_READ)
 if(WIN32)
-    add_custom_command(TARGET Silo POST_BUILD
+    add_custom_command(TARGET SiloPy POST_BUILD
             COMMAND ${CMAKE_COMMAND} -E copy_if_different
             ${CMAKE_CURRENT_SOURCE_DIR}/s2ex.py
             ${Silo_BINARY_DIR}/bin/$<CONFIG>)
 else()
-    add_custom_command(TARGET Silo POST_BUILD
+    add_custom_command(TARGET SiloPy POST_BUILD
             COMMAND ${CMAKE_COMMAND} -E copy_if_different
             ${CMAKE_CURRENT_SOURCE_DIR}/s2ex.py
             ${Silo_BINARY_DIR}/bin/)


### PR DESCRIPTION
Ensure all appropriate dlls are copied to the test directory.
 Required mods to FindHDF5, FindSzip, FindZlib and FindPython.

Rename python module target from `Silo` to `SiloPy` to prevent conflict with `silo` library target.

Update config-site file for my windows machine.