### PR TITLE
Fix some memory leaks

### DIFF
--- a/src/pdb_drv/silo_pdb.c
+++ b/src/pdb_drv/silo_pdb.c
@@ -4019,8 +4019,10 @@ db_pdb_GetMultimesh (DBfile *_dbfile, char const *objname)
        *  them into separate names.
        *----------------------------------------*/
 
-      if ((tmpnames != NULL) && (mm->nblocks > 0)) {
-         db_StringListToStringArrayMBOpt(tmpnames, &(mm->meshnames), &(mm->meshnames_alloc), mm->nblocks);
+      if (tmpnames != NULL) {
+         if (mm->nblocks > 0)
+             db_StringListToStringArrayMBOpt(tmpnames, &(mm->meshnames), &(mm->meshnames_alloc), mm->nblocks);
+         FREE(tmpnames);
       }
       if ((tmpgnames != NULL) && (mm->lgroupings > 0)) {
          mm->groupnames = DBStringListToStringArray(tmpgnames, &(mm->lgroupings), !skipFirstSemicolon);
@@ -4295,8 +4297,10 @@ db_pdb_GetMultivar (DBfile *_dbfile, char const *objname)
        *  them into separate names.
        *----------------------------------------*/
 
-      if (tmpnames != NULL && mv->nvars > 0) {
-         db_StringListToStringArrayMBOpt(tmpnames, &(mv->varnames), &(mv->varnames_alloc), mv->nvars);
+      if (tmpnames != NULL) {
+         if (mv->nvars > 0)
+             db_StringListToStringArrayMBOpt(tmpnames, &(mv->varnames), &(mv->varnames_alloc), mv->nvars);
+         FREE(tmpnames);
       }
 
       if (rpnames != NULL)
@@ -4432,9 +4436,10 @@ db_pdb_GetMultimat (DBfile *_dbfile, char const *objname)
        *  them into separate names.
        *----------------------------------------*/
 
-      if (tmpnames != NULL && mt->nmats > 0)
-      {
-          db_StringListToStringArrayMBOpt(tmpnames, &(mt->matnames), &(mt->matnames_alloc), mt->nmats);
+      if (tmpnames != NULL) {
+          if (mt->nmats > 0)
+              db_StringListToStringArrayMBOpt(tmpnames, &(mt->matnames), &(mt->matnames_alloc), mt->nmats);
+          FREE(tmpnames);
       }
 
       if (tmpmaterial_names && mt->nmatnos > 0)
@@ -4551,9 +4556,11 @@ db_pdb_GetMultimatspecies (DBfile *_dbfile, char const *objname)
        *  break them into separate names.
        *----------------------------------------*/
 
-      if (tmpnames != NULL && mms->nspec > 0)
+      if (tmpnames != NULL)
       {
-          db_StringListToStringArrayMBOpt(tmpnames, &(mms->specnames), &(mms->specnames_alloc), mms->nspec);
+          if (mms->nspec > 0)
+              db_StringListToStringArrayMBOpt(tmpnames, &(mms->specnames), &(mms->specnames_alloc), mms->nspec);
+          FREE(tmpnames);
       }
 
       if (tmpspecnames != NULL)
@@ -6808,17 +6815,11 @@ db_pdb_ReadMatVals(DBfile *_dbfile, char const *vname, int objtype,
         if (mat->matlist[i] >= 0) continue;
 
         mixidx = -(mat->matlist[i]);
-printf("mixidx = %d\n", mixidx);
-printf("dsname[1] = \"%s\"\n", dsnames[1]);
-printf("dsname[2] = \"%s\"\n", dsnames[2]);
-printf("dsname[3] = \"%s\"\n", dsnames[3]);
 
         while (mixidx != 0)
         {
             ind[0] = mixidx-1; ind[1] = mixidx-1; ind[2] = 1;
             PJ_read_alt(dbfile->pdb, (char*)dsnames[2], &mix_next, ind);
-printf("ind[0]=%ld,ind[1]=%ld,ind[2]=%ld\n",ind[0],ind[1],ind[2]);
-printf("mix_next = %d\n",mix_next);
             PJ_read_alt(dbfile->pdb, (char*)dsnames[1], &mix_vf, ind);
             if (memcmp(halfa,halfc,halfn) == 0 || memcmp(halfb,halfd,halfn) == 0)
             {

--- a/tests/empty.c
+++ b/tests/empty.c
@@ -296,6 +296,7 @@ main(int argc, char *argv[])
         /*ASSERT(DBWrite(dbfile,"empty_writeb",0,    0,ZZ,DB_FLOAT),retval<0,retval==0);*/
     }
 
+    DBFreeOptlist(ol);
     DBClose(dbfile);
     dbfile = 0;
 

--- a/tests/json.c
+++ b/tests/json.c
@@ -112,8 +112,8 @@ main(int argc, char *argv[])
 
     /* Example of getting a Silo object from a silo file as a json object */
     jsilo_obj = DBGetJsonObject(dbfile, "hex");
-    printf("%s\n", json_object_to_json_string_ext(jsilo_obj, 0));
     DBClose(dbfile);
+    printf("%s\n", json_object_to_json_string_ext(jsilo_obj, 0));
 
     /* Test interface to query extptr members from jsilo_obj */
     {
@@ -194,6 +194,7 @@ main(int argc, char *argv[])
     /* Example of taking a standard silo object and adding some arbitrary stuff to it */
     json_object_to_file("onehex.json", jsilo_obj);
     json_object_put(jsilo_obj);
+
     fil_obj = json_object_from_file("onehex.json");
     json_object_reconstitute_extptrs(fil_obj);
     printf("fil_obj=%s\n", json_object_to_json_string(fil_obj));

--- a/tests/multi_test.c
+++ b/tests/multi_test.c
@@ -3392,6 +3392,8 @@ build_block_ucd3d(DBfile *dbfile, char dirnames[MAXBLOCKS][STRLEN],
     FREE(mix_next);
     FREE(mix_mat);
     FREE(mix_zone);
+    FREE(mix_zone2);
+    FREE(mix_zone_map);
     FREE(matlist2);
     FREE(ghost);
 


### PR DESCRIPTION
This update fixes some memory leaks discovered using macOS `leaks` tool.

- empty multi-block objects leaked their `names` member
- some client testing code leaked the data it was creating to write to silo
- I re-worked how the json interface's *string pointer* (`strptr`) was handled for `extptr` objects (which are an ensemble of 4 json objects, `string:ptr`, `int:datatype`, `int:ndims` and `array:dims`). Previously the allocation and deletion of the raw data in `ptr` was handled a the `extptr` level (one level up from the `strptr`).
- I also fixed use of some unnecessary `strdup` calls