### PR TITLE
Fix missing matname member of DBmultimatspec

### DIFF
--- a/src/hdf5_drv/silo_hdf5.c
+++ b/src/hdf5_drv/silo_hdf5.c
@@ -14846,6 +14846,7 @@ db_hdf5_GetMultimatspecies(DBfile *_dbfile, char const *name)
 
         /* Create object and initialize meta data */
         if (NULL==(mm=DBAllocMultimatspecies(0))) return NULL;
+        mm->matname = OPTDUP(m.matname);
         mm->nspec = m.nspec;
         mm->ngroups = m.ngroups;
         mm->blockorigin = m.blockorigin;

--- a/src/pdb_drv/silo_pdb.c
+++ b/src/pdb_drv/silo_pdb.c
@@ -4022,7 +4022,7 @@ db_pdb_GetMultimesh (DBfile *_dbfile, char const *objname)
       if (tmpnames != NULL) {
          if (mm->nblocks > 0)
              db_StringListToStringArrayMBOpt(tmpnames, &(mm->meshnames), &(mm->meshnames_alloc), mm->nblocks);
-         FREE(tmpnames);
+       /*FREE(tmpnames); We don't free this here because the MBOpt routine creates pointers into it. */
       }
       if ((tmpgnames != NULL) && (mm->lgroupings > 0)) {
          mm->groupnames = DBStringListToStringArray(tmpgnames, &(mm->lgroupings), !skipFirstSemicolon);
@@ -4300,7 +4300,7 @@ db_pdb_GetMultivar (DBfile *_dbfile, char const *objname)
       if (tmpnames != NULL) {
          if (mv->nvars > 0)
              db_StringListToStringArrayMBOpt(tmpnames, &(mv->varnames), &(mv->varnames_alloc), mv->nvars);
-         FREE(tmpnames);
+       /*FREE(tmpnames); We don't free this here because the MBOpt routine creates pointers into it. */
       }
 
       if (rpnames != NULL)
@@ -4439,7 +4439,7 @@ db_pdb_GetMultimat (DBfile *_dbfile, char const *objname)
       if (tmpnames != NULL) {
           if (mt->nmats > 0)
               db_StringListToStringArrayMBOpt(tmpnames, &(mt->matnames), &(mt->matnames_alloc), mt->nmats);
-          FREE(tmpnames);
+        /*FREE(tmpnames); We don't free this here because the MBOpt routine creates pointers into it. */
       }
 
       if (tmpmaterial_names && mt->nmatnos > 0)
@@ -4560,7 +4560,7 @@ db_pdb_GetMultimatspecies (DBfile *_dbfile, char const *objname)
       {
           if (mms->nspec > 0)
               db_StringListToStringArrayMBOpt(tmpnames, &(mms->specnames), &(mms->specnames_alloc), mms->nspec);
-          FREE(tmpnames);
+          /*FREE(tmpnames); We don't free this here because the MBOpt routine creates pointers into it. */
       }
 
       if (tmpspecnames != NULL)

--- a/src/pdb_drv/silo_pdb.c
+++ b/src/pdb_drv/silo_pdb.c
@@ -4539,6 +4539,7 @@ db_pdb_GetMultimatspecies (DBfile *_dbfile, char const *objname)
       DEFALL_OBJ("empty_list", &tmpmms.empty_list, DB_INT);
       DEFINE_OBJ("empty_cnt", &tmpmms.empty_cnt, DB_INT);
       DEFINE_OBJ("repr_block_idx", &tmpmms.repr_block_idx, DB_INT);
+      DEFALL_OBJ("matname", &tmpmms.matname, DB_CHAR);
 
       if (PJ_GetObject(dbfile->pdb, objname, &tmp_obj, DB_MULTIMATSPECIES) < 0)
          return NULL;

--- a/src/silo/alloc.c
+++ b/src/silo/alloc.c
@@ -462,12 +462,14 @@ DBFreeMultimesh(DBmultimesh *msh)
     if (msh->meshnames_alloc)
     {
         FREE(msh->meshnames_alloc);
+        FREE(msh->meshnames);
     }
     else if (msh->meshnames)
     {
         for (i = 0; i < msh->nblocks; i++) {
             FREE(msh->meshnames[i]);
         }
+        FREE(msh->meshnames);
     }
 
     if (msh->groupnames)
@@ -483,7 +485,6 @@ DBFreeMultimesh(DBmultimesh *msh)
     FREE(msh->zonecounts);
     FREE(msh->has_external_zones);
     FREE(msh->meshids);
-    FREE(msh->meshnames);
     FREE(msh->meshtypes);
     FREE(msh->dirids);
     FREE(msh->mrgtree_name);
@@ -574,12 +575,14 @@ DBFreeMultivar (DBmultivar *mv)
      if (mv->varnames_alloc)
      {
          FREE(mv->varnames_alloc);
+         FREE(mv->varnames);
      }
      else if (mv->varnames)
      {
          for (i = 0; i < mv->nvars; i++) {
               FREE(mv->varnames[i]);
          }
+         FREE(mv->varnames);
      }
 
      if (mv->region_pnames)
@@ -589,7 +592,6 @@ DBFreeMultivar (DBmultivar *mv)
          FREE(mv->region_pnames);
      }
 
-     FREE(mv->varnames);
      FREE(mv->vartypes);
      FREE(mv->mmesh_name);
      FREE(mv->extents);
@@ -641,14 +643,15 @@ DBFreeMultimat (DBmultimat *mat)
      if (mat->matnames_alloc)
      {
          FREE(mat->matnames_alloc);
+         FREE(mat->matnames);
      }
      else if (mat->matnames)
      {
          for (i = 0; i < mat->nmats; i++) {
               FREE(mat->matnames[i]);
          }
+         FREE(mat->matnames);
      }
-     FREE(mat->matnames);
      if (mat->material_names)
      {
          for (i = 0; i < mat->nmatnos; i++)
@@ -735,14 +738,15 @@ DBFreeMultimatspecies (DBmultimatspecies *spec)
      if (spec->specnames_alloc)
      {
          FREE(spec->specnames_alloc);
+         FREE(spec->specnames);
      }
      else if (spec->specnames)
      {
          for (i = 0; i < spec->nspec; i++) {
               FREE(spec->specnames[i]);
          }
+         FREE(spec->specnames);
      }
-     FREE(spec->specnames);
 
      FREE(spec->nmatspec);
      FREE(spec->file_ns);

--- a/src/silo/silo.h.in
+++ b/src/silo/silo.h.in
@@ -1011,6 +1011,7 @@ typedef struct DBmultimatspecies_ {
     int            empty_cnt;   /* size of empty list */
     int            repr_block_idx; /* index of a 'representative' block */
     char          *specnames_alloc; /* original alloc of matnames as string list */
+    char          *matname; /* associated multi-mat object name */
 } DBmultimatspecies;
 
 /*----------------------------------------------------------------------

--- a/tools/browser/stc.c
+++ b/tools/browser/stc.c
@@ -1771,6 +1771,7 @@ stc_silo_types (void) {
       COMP (ngroups,            "primitive 'int'");
       COMP (guihide,            "primitive 'int'");
       IOASSOC (PA_BOOLEAN);
+      COMP (matname,            "primitive 'string'");
       COMP (blockorigin,        "primitive 'int'");
       COMP (grouporigin,        "primitive 'int'");
       COMP (nmat,               "primitive 'int'");


### PR DESCRIPTION
This fixes an oversight in retrieving `DBmultimatspecies` objects from HDF5 and PDB files. The `matname` member was not being handled.

It also fixes a memory bug in PDB driver for handling string-list-to-string-array conversion in the *optimized* cases for multi-block object block names.