### PR TITLE
Fix a problem compiling for PDB only

### DIFF
--- a/tests/memfile_simple.c
+++ b/tests/memfile_simple.c
@@ -227,7 +227,7 @@ main(int argc, char *argv[])
     }
     ASSERT(DBCp("-r", srcdb, dstdb, "mat1", "foo", DB_EOA)>=0, "");
 
-#if HAVE_HDF5_H
+#ifdef HAVE_HDF5_H
     /* Ok, we've created a "core" file. Lets flush it and get the
      * buffer of it back */
     {


### PR DESCRIPTION
When building with just the PDB driver, I ran into problems with some test code. Fixed here.