### PR TITLE
Silo Fortran API builder indicates integer(kind=4)

### DIFF
--- a/config/mkinc
+++ b/config/mkinc
@@ -396,7 +396,7 @@ foreach $var (@temparray) {
             }
         } else {
             if ($opt_f90) {
-	        $value .= '_4' if ($value =~ /^[\+\-\d]+$/) ;
+	            $value .= '_4' if ($value =~ /^[\+\-\d]+$/) ;
                 $ftype = 'integer(kind=4)';
             } else {
                 $ftype = 'integer*4';
@@ -416,7 +416,7 @@ foreach $var (@temparray) {
                     printf '     & ' . $2 . "\n";
                     # evaluating the rhs value leads to short line
                     last ;
-		} else {
+		        } else {
                     $curline = substr($line, $off, $off+64);
                     if ($off == 0) {
                         printf "$curline\n";


### PR DESCRIPTION
When using the Silo Fortran API, one includes the silo_f9x.inc header and thus compiles it's content.
When the compiler is instructed to promote integers to double precision, the variables from silo_f9x.inc are promoted to long integers, which is wrong. Promotion for Intel compiler is "`-i8`", for gfortran is "`-fdefault-integer-8`".
So, `config/mkinc` sets the integer length to 4 bytes for integers, externals as well as parameters.
This may have an impact on client codes if they use the silo_f9x.inc privately with double precision promotion, something people should not do.
The same is applied to the fortran 77 include.

