### PR TITLE
Improved `SiloFindHDF5.cmake` Search

### DIFF
--- a/CMake/SiloFindHDF5.cmake
+++ b/CMake/SiloFindHDF5.cmake
@@ -90,7 +90,7 @@ if(NOT HDF5_FOUND)
     
 endif()
 
-#if(HDF5_FOUND)
+if(HDF5_FOUND)
     # needed for config.h
     set(HAVE_HDF5_H 1)
     set(HAVE_HDF5_DRIVER 1)


### PR DESCRIPTION
There is an inherent issue with Cray Compiling Environment (CCE) where `find_package(HDF5)` won't suffice, even though all necessary modules are loaded. Thus, I just applied [FindHDF5.cmake](https://github.com/MFlowCode/MFC/blob/2d1de77b5cf1e8b0977e4937eb1222803d8286e2/toolchain/cmake/cce/FindHDF5.cmake) to Silo directly for better HDF5 search. The fix was tested on ORNL Frontier.

Reference [[https://github.com/MFlowCode/MFC/issues/621](https://github.com/MFlowCode/MFC/issues/621)]