### PR TITLE
Fix various compile issues using MSVC on Windows to build.

### DIFF
--- a/CMake/SiloFindQt6.cmake
+++ b/CMake/SiloFindQt6.cmake
@@ -60,7 +60,7 @@
 
 if(DEFINED SILO_QT6_DIR AND EXISTS ${SILO_QT6_DIR})
     # set the variable needed for CMake to find this version of Qt
-    set(Qt6_DIR ${SILO_QT6_DIR})
+    set(CMAKE_PREFIX_PATH ${CMAKE_PREFIX_PATH} ${SILO_QT6_DIR}/lib/cmake)
 endif()
 
 find_package(Qt6 COMPONENTS Core Gui Widgets CONFIG)

--- a/CMake/SiloFindZlib.cmake
+++ b/CMake/SiloFindZlib.cmake
@@ -58,12 +58,11 @@
 #   If SILO_ZLIB_DIR is defined, uses it to tell CMake where to look.
 #   Use CONFIG version of find_package if zlib-config.cmake exists.
 ###
-
-if(DEFINED SILO_ZLIB_DIR AND EXISTS ${SILO_ZLIB_DIR}/zlib-config.cmake)
+if(SILO_ZLIB_DIR AND EXISTS ${SILO_ZLIB_DIR}/cmake/zlib-config.cmake)
     # this works for zlib with CMake
     find_package(ZLIB PATHS ${SILO_ZLIB_DIR} CONFIG NO_DEFAULT_PATH)
 else()
-    if(DEFINED SILO_ZLIB_DIR AND EXISTS ${SILO_ZLIB_DIR})
+    if(SILO_ZLIB_DIR AND EXISTS ${SILO_ZLIB_DIR})
         # help CMake find the specified zlib
         set(ZLIB_ROOT ${SILO_ZLIB_DIR})
     endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -141,7 +141,7 @@ include(CMakeDependentOption)
 # only turn on the visibility of SILO_ENABLE_ZFP if SILO_ENABLE_HDF5 is ON
 # in which case SILO_ENABLE_ZFP defaults to ON
 CMAKE_DEPENDENT_OPTION(SILO_ENABLE_ZFP "Enable Lindstrom array compression" ON
-                       SILO_ENABLE_HDF5 OFF)
+                       "SILO_ENABLE_HDF5; NOT WIN32" OFF)
 
 # only turn on the visibility of SILO_ENABLE_FPZIP if
 # SILO_BUILD_FOR_BSD is OFF AND SILO_ENABLE_HDF5 is ON
@@ -197,6 +197,13 @@ if(WIN32 AND (SILO_ENABLE_SILEX OR SILO_ENABLE_BROWSER))
     add_custom_target(copy_deps ALL)
     set_target_properties(copy_deps PROPERTIES FOLDER utility)
 endif()
+
+###-----------------------------------------------------------------------------
+# Define and populate CMAKE_INSTALL_*DIR variables
+# Needs to be before the inclusion of SiloFind modules, as some of them may
+# attempt to use the variables set.
+###-----------------------------------------------------------------------------
+include(GNUInstallDirs)
 
 ###---------------------------------------------------------------------------
 # Find necessary packages
@@ -348,10 +355,6 @@ configure_file(${Silo_SOURCE_DIR}/src/silo/silo.h.in
                ${silo_build_include_dir}/silo.h)
 
 
-###-----------------------------------------------------------------------------
-# Define and populate CMAKE_INSTALL_*DIR variables
-###-----------------------------------------------------------------------------
-include(GNUInstallDirs)
 
 if(SILO_ENABLE_FORTRAN)
     enable_language(Fortran)

--- a/src/hdf5_drv/silo_hdf5.c
+++ b/src/hdf5_drv/silo_hdf5.c
@@ -16803,7 +16803,7 @@ db_hdf5_SortObjectsByOffset(DBfile *_dbfile, int nobjs,
         else
         {
             hid_t objid;
- 	    H5O_info2_t oinfo;
+            H5O_info2_t oinfo;
             char *objtokstr = 0;
             unsigned long long offset;
 

--- a/src/silo/silo.c
+++ b/src/silo/silo.c
@@ -6875,7 +6875,9 @@ DBWriteComponent(DBfile *dbfile, DBobject *obj, char const *comp_name,
             API_ERROR("component name", E_BADARGS);
         if (db_VariableNameValid((char *)comp_name) == 0)
             API_ERROR("component name", E_INVALIDNAME);
+#ifndef _MSC_VER
 #warning FIXME
+#endif
 #if 0
         /* We don't know what name to pass to DBInqVarExists here because it
            is the driver that knows how to construct component names */

--- a/src/silo/silo_win32_compatibility.h
+++ b/src/silo/silo_win32_compatibility.h
@@ -23,6 +23,15 @@
     #define S_IWUSR _S_IWRITE
   #endif
 #endif
+
+#ifndef S_IRUSR
+  #ifdef S_IREAD
+    #define S_IRUSR S_IREAD
+  #else
+    #define S_IRUSR _S_IREAD
+  #endif
+#endif
+
 #ifndef S_ISREG
   #define S_ISREG(x) (((x) & S_IFMT) == S_IFREG)
 #endif


### PR DESCRIPTION
GNUInstallDirs needs to come before SiloFind modules since some of the find module may use the cmake vars set by GNUInstallDirs.

Wrapped a #warning.

Changes to SiloFindQt6 and SiloFindZlib to work on Windows (may need to verify it didn't break things on other platforms.

Disabled ZFP when building on windows.

Add definition of S_IRUSR.