### PR TITLE
filter rpm ci to src changes

### DIFF
--- a/.github/workflows/detect-source-changes.yml
+++ b/.github/workflows/detect-source-changes.yml
@@ -1,0 +1,38 @@
+name: Detect source changes
+
+on:
+  workflow_call:
+    outputs:
+      run_build:
+        description: "Whether non-doc/source-relevant files changed"
+        value: ${{ jobs.changes.outputs.run_build }}
+
+jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      run_build: ${{ steps.filter.outputs.build }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Detect source changes
+        id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            build:
+              - '**'
+              - '!.github/**'
+              - '.github/workflows/**'
+              - '!**/*.md'
+              - '!docs/**'
+              - '!ghpages/**'
+              - '!svn_bin/**'
+              - '!README.md'
+              - '!LICENSE'
+              - '!COPYRIGHT'
+              - '!SILO_VERSION'
+              - '!INSTALL'
+              - '!_config.yml'
+              - '!.readthedocs.yaml'
+              - '!examples.gif'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,12 +10,23 @@ on:
       - '[0-9]*.[0-9]*.[0-9]*RC'
 
 concurrency:
-  group: ${ {github.event_name }}-${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.event_name }}-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
+  changes:
+    uses: ./.github/workflows/detect-source-changes.yml
+
   build:
-    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
+    needs: changes
+    if: >-
+      ${{
+        github.event_name == 'workflow_dispatch' ||
+        (
+          (github.event_name != 'pull_request' || github.event.pull_request.draft == false) &&
+          needs.changes.outputs.run_build == 'true'
+        )
+      }}
     runs-on: ubuntu-latest
 
     steps:
@@ -126,7 +137,6 @@ jobs:
         if-no-files-found: ignore
         retention-days: 14
 
-    # Re-signal the failure so the job ends red.
     - name: Fail job if make check failed
       if: ${{ steps.makecheck-cmake.outcome == 'failure' || steps.makecheck-cmake-asan.outcome == 'failure' }}
       run: exit 1

--- a/.github/workflows/rpmbuild.yml
+++ b/.github/workflows/rpmbuild.yml
@@ -1,4 +1,5 @@
 name: rpmbuild
+
 on:
   workflow_dispatch:
   pull_request:
@@ -9,12 +10,44 @@ on:
       - '[0-9].[0-9][0-9]RC'
 
 concurrency:
-  group: ${ {github.event_name }}-${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true 
+  group: ${{ github.event_name }}-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      run_rpmbuild: ${{ steps.filter.outputs.rpmbuild }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Detect source changes
+        id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            rpmbuild:
+              - '**'
+              - '!.github/**'
+              - '.github/workflows/**'
+              - '!**/*.md'
+              - '!docs/**'
+              - '!ghpages/**'
+              - '!README*'
+              - '!LICENSE*'
+              - '!COPYING*'
+
   rpmbuild:
-    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
+    needs: changes
+    if: >-
+      ${{
+        (github.event_name == 'workflow_dispatch') ||
+        (
+          (github.event_name != 'pull_request' || github.event.pull_request.draft == false) &&
+          needs.changes.outputs.run_rpmbuild == 'true'
+        )
+      }}
     continue-on-error: ${{ matrix.config.continue-on-error == 'true' }}
     strategy:
       matrix:
@@ -23,24 +56,28 @@ jobs:
           - {arch: 'amd64'}
     runs-on: ${{ matrix.config.arch == 'arm64' && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}
     container: fedora:latest
+
     steps:
       - name: Install fedpkg
         run: dnf -y install fedpkg
+
       - name: Checkout code
         uses: actions/checkout@v6
         with:
           path: Silo
+
       - name: Prepare rpmbuild
         run: |
           mkdir Silo.rpm
           tar -cvzf Silo-9999.tar.gz Silo/
           cp Silo-9999.tar.gz Silo/.github/workflows/Silo.spec Silo.rpm
+
       - name: Install build deps
         working-directory: Silo.rpm
         run: |
           dnf -y builddep Silo.spec
+
       - name: Build rpm
         working-directory: Silo.rpm
         run: |
           fedpkg --verbose --debug local
-

--- a/.github/workflows/rpmbuild.yml
+++ b/.github/workflows/rpmbuild.yml
@@ -15,37 +15,16 @@ concurrency:
 
 jobs:
   changes:
-    runs-on: ubuntu-latest
-    outputs:
-      run_rpmbuild: ${{ steps.filter.outputs.rpmbuild }}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
-
-      - name: Detect source changes
-        id: filter
-        uses: dorny/paths-filter@v3
-        with:
-          filters: |
-            rpmbuild:
-              - '**'
-              - '!.github/**'
-              - '.github/workflows/**'
-              - '!**/*.md'
-              - '!docs/**'
-              - '!ghpages/**'
-              - '!README*'
-              - '!LICENSE*'
-              - '!COPYING*'
+    uses: ./.github/workflows/detect-source-changes.yml
 
   rpmbuild:
     needs: changes
     if: >-
       ${{
-        (github.event_name == 'workflow_dispatch') ||
+        github.event_name == 'workflow_dispatch' ||
         (
           (github.event_name != 'pull_request' || github.event.pull_request.draft == false) &&
-          needs.changes.outputs.run_rpmbuild == 'true'
+          needs.changes.outputs.run_build == 'true'
         )
       }}
     continue-on-error: ${{ matrix.config.continue-on-error == 'true' }}


### PR DESCRIPTION
This PR adjusts CI workflows to ensure tests are run only when changes to files impacting code are made. So, changes to documentation will not trigger CI.

It also uses a new kind of feature of GitHub actions called a *reusable workflow*. That way, only one place contains knowledge of which files are considered code.

That reusable workflow is then used within the `main.yml` and `rpmbuild.yml`.