### PR TITLE
CMakeLists: use list(APPEND) for CMAKE_MODULE_PATH

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,7 +79,7 @@ project(Silo VERSION ${SILO_VERSION} LANGUAGES CXX C)
 ###-----------------------------------------------------------------------------
 # location for Silo CMake includes
 ###-----------------------------------------------------------------------------
-set(CMAKE_MODULE_PATH ${Silo_SOURCE_DIR}/CMake)
+list(APPEND CMAKE_MODULE_PATH "${Silo_SOURCE_DIR}/CMake")
 
 ###-----------------------------------------------------------------------------
 # If not already set, use a default build type of Release
@@ -934,4 +934,3 @@ install(FILES ${Silo_BINARY_DIR}/cmake/SiloConfig.cmake
         PERMISSIONS OWNER_READ OWNER_WRITE
                     GROUP_READ GROUP_WRITE
                     WORLD_READ)
-


### PR DESCRIPTION
## Problem

`CMakeLists.txt` currently uses `set()` to register Silo's CMake module directory:

```cmake
set(CMAKE_MODULE_PATH ${Silo_SOURCE_DIR}/CMake)
```

`set()` **replaces** `CMAKE_MODULE_PATH` entirely, silently discarding any value passed by a parent or superbuild system via `-DCMAKE_MODULE_PATH=...`. This means any custom `FindXXX.cmake` modules injected by the parent are lost before `SiloFindHDF5.cmake` runs.

## Impact

This breaks superbuild systems that embed Silo as a dependency and need to inject custom CMake finders for non-standard environments. A concrete example: [MFC](https://github.com/MFlowCode/MFC), an exascale CFD solver, targets Cray HPC clusters where CMake's built-in `FindHDF5.cmake` does not locate HDF5 correctly. MFC injects a Cray-specific finder via `-DCMAKE_MODULE_PATH=...`. With the current `set()`, that path is wiped out, and the build fails:

```
CMake Error at CMake/SiloFindHDF5.cmake:92 (message):
  An explicit request for HDF5 was made but HDF5 was not found.
  You may want to try setting SILO_HDF5_DIR
```

MFC currently works around this by patching Silo at build time, but that patch exists solely because of this one line.

## Fix

Change `set()` to `list(APPEND)`:

```cmake
list(APPEND CMAKE_MODULE_PATH "${Silo_SOURCE_DIR}/CMake")
```

This preserves any externally-set module paths while still making Silo's own `CMake/` directory available — standard CMake practice for project-internal module directories.

**No behavior change** for standalone Silo builds where `CMAKE_MODULE_PATH` is empty or unset at entry.