### PR TITLE
Fix and test file locking behavior

### DIFF
--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (C) 1994-2016 Lawrence Livermore National Security, LLC.
+Copyright (C) 1994-2026 Lawrence Livermore National Security, LLC.
 LLNL-CODE-425250.
 All rights reserved.
 

--- a/src/hdf5_drv/silo_hdf5.c
+++ b/src/hdf5_drv/silo_hdf5.c
@@ -2057,15 +2057,18 @@ silo_walk_cb(unsigned n, const H5E_error2_t *err_desc, void *client_data)
 {
     int *silo_error_code_p = (int *) client_data;
 
-    /* Note that error code can be overwritten by later strstr
-       comparisons. Where both checksum and compression errors
-       occur, we declare it a compression error. */
-    if (strstr(err_desc->desc, "letcher32") != 0)
+    if (*silo_error_code_p != E_NOERROR)
+        return 0;
+
+    if      (strstr(err_desc->desc, "letcher32") != 0)
         *silo_error_code_p = E_CHECKSUM;
-    if (strstr(err_desc->desc, "zip") != 0)
+    else if (strstr(err_desc->desc, "zip") != 0)
         *silo_error_code_p = E_COMPRESSION;
-    if (strstr(err_desc->desc, "Lindstrom-") != 0)
+    else if (strstr(err_desc->desc, "Lindstrom-") != 0)
         *silo_error_code_p = E_COMPRESSION;
+    else if (err_desc->min_num == H5E_CANTLOCKFILE ||
+            (strstr(err_desc->desc, "lock") != 0))
+        *silo_error_code_p = E_FILELOCKING;
 
     return 0;
 }
@@ -2084,14 +2087,14 @@ silo_walk_cb(unsigned n, const H5E_error2_t *err_desc, void *client_data)
  *-------------------------------------------------------------------------
  */
 PRIVATE void
-hdf5_to_silo_error(char const *vname, char const *fname)
+hdf5_to_silo_error(char const *vname, char const *fname, int generic_error_code)
 {
     int silo_error_code = E_NOERROR;
 
     H5Ewalk(H5E_DEFAULT, H5E_WALK_UPWARD, silo_walk_cb, &silo_error_code);
 
     if (silo_error_code == E_NOERROR)
-        silo_error_code = E_CALLFAIL;
+        silo_error_code = generic_error_code;
 
     db_perror((char*)vname, silo_error_code, (char*)fname);
 }
@@ -3935,7 +3938,7 @@ db_hdf5_get_comp_var(DBfile *_dbfile, char const *name, hsize_t *nelmts,
                         P_rdprops = P_ckrdprops;
 
                     if (H5Dread(d, mtype, H5S_ALL, H5S_ALL, P_rdprops, *buf)<0) {
-                        hdf5_to_silo_error(name, "db_hdf5_get_comp_var");
+                        hdf5_to_silo_error(name, "db_hdf5_get_comp_var", E_CALLFAIL);
                         if (buf_was_allocated)
                         {
                             free(*buf);
@@ -4518,7 +4521,7 @@ db_hdf5_compwrz(DBfile_hdf5 *dbfile, int dtype, int rank, int const _size[],
         }
 
         if (buf && H5Dwrite(dset, mtype, space, space, H5P_DEFAULT, buf)<0) {
-            hdf5_to_silo_error(name, "db_hdf5_compwrz");
+            hdf5_to_silo_error(name, "db_hdf5_compwrz", E_CALLFAIL);
             UNWIND();
         }
 
@@ -4688,7 +4691,7 @@ db_hdf5_comprd(DBfile_hdf5 *dbfile, char *name, int ignore_force_single)
                 P_rdprops = P_ckrdprops;
 
             if (H5Dread(d, mtype, H5S_ALL, H5S_ALL, P_rdprops, buf)<0) {
-                hdf5_to_silo_error(name, me);
+                hdf5_to_silo_error(name, me, E_CALLFAIL);
                 UNWIND();
             }
 
@@ -5008,6 +5011,9 @@ db_hdf5_ForceSingle(int status)
  *  Mark C. Miller, Wed Aug  4 16:06:41 PDT 2010
  *  Added conditional compilation logic for silo fapl for HDF5 1.8.4 or
  *  greater.
+ *
+ *  Mark C. Miller, Thu May 21 20:39:57 PDT 2026
+ *  Disable file locking.
  *-------------------------------------------------------------------------
  */
 PRIVATE hid_t
@@ -5029,6 +5035,7 @@ db_hdf5_process_file_options(int opts_set_id, int mode, hid_t *fcpl)
 
 #if HDF5_VERSION_GE(1,10,1)
     H5Pset_evict_on_close(retval, (hbool_t)1);
+    H5Pset_file_locking(retval, FALSE, FALSE); /* disable file locking */
 #endif
 
     /* First, initialize our copy of h5mdc_config */
@@ -6000,8 +6007,8 @@ db_hdf5_Open(char const *name, int mode, int opts_set_id)
 
     /* Open existing hdf5 file */
     if ((fid=H5Fopen(name, hmode, faprops))<0) {
+        hdf5_to_silo_error(name, me, E_DRVRCANTOPEN);
         H5Pclose(faprops);
-        db_perror(name, E_DRVRCANTOPEN, me);
         return NULL;
     }
 
@@ -6129,8 +6136,8 @@ db_hdf5_Create(char const *name, int mode, int target, int opts_set_id, char con
         return NULL;
     }
     if (fid<0) {
+        hdf5_to_silo_error(name, me, E_NOFILE);
         H5Pclose(faprops);
-        db_perror(name, E_NOFILE, me);
         return NULL;
     }
 
@@ -8246,7 +8253,7 @@ db_hdf5_GetVar(DBfile *_dbfile, char const *name)
 
                 /* Read entire variable */
                 if (H5Dread(dset, mtype, H5S_ALL, H5S_ALL, P_rdprops, result)<0) {
-                    hdf5_to_silo_error(name, me);
+                    hdf5_to_silo_error(name, me, E_CALLFAIL);
                     UNWIND();
                 }
             }
@@ -8324,7 +8331,7 @@ db_hdf5_ReadVar(DBfile *_dbfile, char const *vname, void *result)
 
            /* Read entire variable */
            if (H5Dread(dset, mtype, H5S_ALL, H5S_ALL, P_rdprops, result)<0) {
-               hdf5_to_silo_error(vname, me);
+               hdf5_to_silo_error(vname, me, E_CALLFAIL);
                UNWIND();
            }
 
@@ -8414,7 +8421,7 @@ db_hdf5_ReadVarSlice(DBfile *_dbfile, char const *vname, int const *offset, int 
 
        /* Read the data */
        if (H5Dread(dset, mtype, mspace, fspace, P_rdprops, result)<0) {
-           hdf5_to_silo_error(vname, me);
+           hdf5_to_silo_error(vname, me, E_CALLFAIL);
            UNWIND();
        }
    
@@ -8535,7 +8542,7 @@ db_hdf5_ReadVarVals(DBfile *_dbfile, char const *vname, int mode,
 
            /* Read the data */
            if (H5Dread(dset, mtype, mspace, fspace, P_rdprops, p)<0) {
-               hdf5_to_silo_error(vname, me);
+               hdf5_to_silo_error(vname, me, E_CALLFAIL);
                UNWIND();
            }
 
@@ -14141,7 +14148,7 @@ db_hdf5_GetMultimeshadj(DBfile *_dbfile, char const *name, int nmesh,
                  if (H5Dread(nldset, mtype, mspace, fspace, P_rdprops, nlist)<0) {
                      FREE(offsetmap); FREE(offsetmapn); FREE(offsetmapz);
                      DBFreeMultimeshadj(mmadj);
-                     hdf5_to_silo_error(name, me);
+                     hdf5_to_silo_error(name, me, E_CALLFAIL);
                      UNWIND();
                  }
 
@@ -14204,7 +14211,7 @@ db_hdf5_GetMultimeshadj(DBfile *_dbfile, char const *name, int nmesh,
                  if (H5Dread(zldset, mtype, mspace, fspace, P_rdprops, zlist)<0) {
                      FREE(offsetmap); FREE(offsetmapn); FREE(offsetmapz);
                      DBFreeMultimeshadj(mmadj);
-                     hdf5_to_silo_error(name, me);
+                     hdf5_to_silo_error(name, me, E_CALLFAIL);
                      UNWIND();
                  }
 

--- a/src/silo/silo.c
+++ b/src/silo/silo.c
@@ -195,7 +195,8 @@ PUBLIC char   *_db_err_list[] =
     "No more tiny array buffer space for custom object.", /* 35 */
     "Although this appears to be an HDF5 file,\n"
     "it does not appear to be one produced by Silo\n"
-    "and so cannot be open and read by Silo." /* 36 */
+    "and so cannot be open and read by Silo.", /* 36 */
+    "File locking has prevented an operation." /* 37 */
 };
 
 /* Table of contents object count */

--- a/src/silo/silo.h.in
+++ b/src/silo/silo.h.in
@@ -604,6 +604,7 @@ typedef enum {
 #define     E_EMPTYOBJECT 34    /*Empty object not currently permitted*/
 #define     E_OBJBUFFULL  35    /*No more temp. buffer space for object */
 #define     E_NOSILOHDF5 36     /*Not HDF5 file produced by silo */
+#define     E_FILELOCKING 37    /*File locking prevented operation */
 #define     E_NERRORS   50
 
 /* Definitions for MAJOR_ORDER */

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -253,6 +253,7 @@ set(HDF5_ONLY_SOURCES
     partial_io.c
     readstuff.c
     testhdf5.c
+    locking.c
 )
 
 set(PDB_ONLY_SOURCES

--- a/tests/locking.c
+++ b/tests/locking.c
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 1994-2016 Lawrence Livermore National Security, LLC.
+Copyright (C) 1994-2026 Lawrence Livermore National Security, LLC.
 LLNL-CODE-425250.
 All rights reserved.
 

--- a/tests/locking.c
+++ b/tests/locking.c
@@ -1,0 +1,120 @@
+/*
+Copyright (C) 1994-2016 Lawrence Livermore National Security, LLC.
+LLNL-CODE-425250.
+All rights reserved.
+
+This file is part of Silo. For details, see silo.llnl.gov.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+   * Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the disclaimer below.
+   * Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the disclaimer (as noted
+     below) in the documentation and/or other materials provided with
+     the distribution.
+   * Neither the name of the LLNS/LLNL nor the names of its
+     contributors may be used to endorse or promote products derived
+     from this software without specific prior written permission.
+
+THIS SOFTWARE  IS PROVIDED BY  THE COPYRIGHT HOLDERS  AND CONTRIBUTORS
+"AS  IS" AND  ANY EXPRESS  OR IMPLIED  WARRANTIES, INCLUDING,  BUT NOT
+LIMITED TO, THE IMPLIED  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A  PARTICULAR  PURPOSE ARE  DISCLAIMED.  IN  NO  EVENT SHALL  LAWRENCE
+LIVERMORE  NATIONAL SECURITY, LLC,  THE U.S.  DEPARTMENT OF  ENERGY OR
+CONTRIBUTORS BE LIABLE FOR  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR  CONSEQUENTIAL DAMAGES  (INCLUDING, BUT NOT  LIMITED TO,
+PROCUREMENT OF  SUBSTITUTE GOODS  OR SERVICES; LOSS  OF USE,  DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER  IN CONTRACT, STRICT LIABILITY,  OR TORT (INCLUDING
+NEGLIGENCE OR  OTHERWISE) ARISING IN  ANY WAY OUT  OF THE USE  OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+This work was produced at Lawrence Livermore National Laboratory under
+Contract  No.   DE-AC52-07NA27344 with  the  DOE.  Neither the  United
+States Government  nor Lawrence  Livermore National Security,  LLC nor
+any of  their employees,  makes any warranty,  express or  implied, or
+assumes   any   liability   or   responsibility  for   the   accuracy,
+completeness, or usefulness of any information, apparatus, product, or
+process  disclosed, or  represents  that its  use  would not  infringe
+privately-owned   rights.  Any  reference   herein  to   any  specific
+commercial products,  process, or  services by trade  name, trademark,
+manufacturer or otherwise does not necessarily constitute or imply its
+endorsement,  recommendation,   or  favoring  by   the  United  States
+Government or Lawrence Livermore National Security, LLC. The views and
+opinions  of authors  expressed  herein do  not  necessarily state  or
+reflect those  of the United  States Government or  Lawrence Livermore
+National  Security, LLC,  and shall  not  be used  for advertising  or
+product endorsement purposes.
+*/
+
+#include <errno.h>
+#include <string.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include "silo.h"
+
+int main(int argc, char **argv)
+{
+    int i;
+    int const create_phase = 1, open_phase = 2;
+    int phase = create_phase;
+    int status;
+    char *new_argv[] = {"open-phase", NULL};
+    pid_t pid;
+    DBfile *db;
+
+    for (i = 0; i < argc; i++)
+    {
+        if (!strcmp(argv[i], "open-phase"))
+            phase = open_phase;
+    }
+
+    if (phase == open_phase)
+    {
+        /* try opening a file already opened by another process in previous phase */
+        DBShowErrors(DB_ALL_AND_DRVR,NULL);
+        db = DBOpen("locktest.silo", DB_HDF5, DB_APPEND);
+        if (!db) return 5;
+        DBClose(db);
+        return 0;
+    }
+
+    /* if we're here, we in the create phase*/
+    db = DBCreate("locktest.silo", DB_CLOBBER, DB_LOCAL, "file locking test", DB_HDF5);
+    DBFlush(db);
+
+    pid = fork();
+    if (pid == -1) return errno;
+
+    if (pid == 0)
+    {
+        /* child is an execv of this same executable with a new arg list */
+        execv(argv[0], new_argv);
+        return errno; /* should never hit */
+    }
+
+    waitpid(pid, &status, 0);
+
+    DBClose(db);
+
+    if (WIFEXITED(status))
+    {
+        if (WEXITSTATUS(status) == 5)
+        {
+            printf("second DBOpen failed: HDF5 locking appears enabled\n");
+            return 1;
+        }
+        if (WEXITSTATUS(status) == 0)
+        {
+            printf("second DBOpen succeeded: HDF5 locking appears disabled\n");
+            return 0;
+        }
+    }
+
+    printf("There was some kind of failure testing file locking is disabled\n");
+    return 1;
+}

--- a/tests/locking.c
+++ b/tests/locking.c
@@ -78,12 +78,16 @@ int main(int argc, char **argv)
         /* try opening a file already opened by another process in previous phase */
         DBShowErrors(DB_ALL_AND_DRVR,NULL);
         db = DBOpen("locktest.silo", DB_HDF5, DB_APPEND);
-        if (!db) return 5;
+        if (!db)
+        {
+            if (DBErrno() == E_FILELOCKING) return 5;
+            return 6;
+        }
         DBClose(db);
         return 0;
     }
 
-    /* if we're here, we in the create phase*/
+    /* if we're here, we're in the create phase */
     db = DBCreate("locktest.silo", DB_CLOBBER, DB_LOCAL, "file locking test", DB_HDF5);
     DBFlush(db);
 
@@ -103,18 +107,23 @@ int main(int argc, char **argv)
 
     if (WIFEXITED(status))
     {
+        if (WEXITSTATUS(status) == 6)
+        {
+            printf("second DBOpen failed for some reason unrelated to locking\n");
+            return 1;
+        }
         if (WEXITSTATUS(status) == 5)
         {
-            printf("second DBOpen failed: HDF5 locking appears enabled\n");
+            printf("second DBOpen failed: HDF5 locking incorrectly appears enabled\n");
             return 1;
         }
         if (WEXITSTATUS(status) == 0)
         {
-            printf("second DBOpen succeeded: HDF5 locking appears disabled\n");
+            printf("second DBOpen succeeded: HDF5 locking correctly appears disabled\n");
             return 0;
         }
     }
 
-    printf("There was some kind of failure testing file locking is disabled\n");
+    printf("There was some kind of failure testing whether file locking is disabled\n");
     return 1;
 }


### PR DESCRIPTION
Back in 1.10.1, HDF5 adjusted its default file locking behavior on sec2 (linux) file driver. Previously, file locking had been an issue only on Windows.

This update...

- adds logic to disable HDF5 file locking
- adds logic to detect if `H5Fopen()` has failed due to file locking issues
- adds a test to test Silo is setting and getting desired HDF5 file locking behavior