### PR TITLE
Handle faux datatype in generic objects and very, very old Silo files in python

### DIFF
--- a/docs/generic.md
+++ b/docs/generic.md
@@ -1107,7 +1107,24 @@ The functions described here allow users to read and write arbitrary arrays of r
 
   The `DBGetComponent` function allocates space for one object component, reads the component, and returns a pointer to that space.
   If either the object or component does not exist, `NULL` is returned.
-  It is up to the application to cast the returned pointer to the appropriate type.
+  It is up to the application to cast the returned pointer to the appropriate type, often obtained with a call to `DBGetComponentType()`.
+
+  :::{note}
+  A component named `datatype` is common across many Silo objects.
+  This component is typically used to hold type information of the object's problem-sized arrays.
+  For example, in a `DBucdvar` object, the `datatype` member is an `int` member holding one of Silo's [`DBdatatype` enum values](./header.md#dbdatatype) indicating the type of data the `void **vals` member of the [`DBucdvar`](./header.md#dbucdvar) points to.
+  In the PDB driver, this `datatype` information is always explicitly stored with every Silo object's metadata.
+  In the HDF5 driver, for reasons that are lost to history, this `datatype` information is most often stored as part of the HDF5 dataset objects holding the problem-sized raw data and not part of the Silo object metadata.
+  This means that for Silo/HDF5 files when a `datatype` component member's value is queried with `DBGetComponent()`, it can sometimes return the type value `DB_FLOAT_OR_DOUBLE`.
+  If `DB_FLOAT_OR_DOUBLE` is observed for value of `datatype`, the true value must be obtained by making other interrogations.
+  A common solution is to examine the `pdb_names` member of the associated [`DBobject`](./header.md#dbobject), assuming one is available such as in this code in the python module...
+
+   ```{literalinclude} ../tools/python/pydbfile.cpp
+   :start-at: "// Handle possible incomplete datatype information"
+   :end-at: "*((int*)comp) = std::stoi(pdbname.substr(4));"
+   ```
+  :::
+
 
 {{ EndFunc }}
 

--- a/docs/header.md
+++ b/docs/header.md
@@ -224,8 +224,8 @@ We include the contents of the Silo header file here including a description of 
 ## Open/Create flags
 
    ```{literalinclude} ../src/silo/silo.h.in
-   :start-at: "/* Flags for DBCreate */"
-   :end-before: "/* Options */"
+   :start-at: "/* Flags for DBCreate"
+   :end-before: "/* File image in core (FIC) flags"
    ```
 
 ## Optlist options

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -1,4 +1,13 @@
-﻿# Introduction to Silo
+﻿%
+% I can use the following commands to build the docs locally
+%
+% rm -rf _build
+% env PYTHONPATH=`pwd`/_ext /Users/miller86/visit/develop/release/build-mb-3.5.0-darwin-24-arm64-release/thirdparty_shared/third_party/python/3.13.9/darwin-arm64/bin/sphinx-build -E -W --keep-going -b html . _build -a
+% /Users/miller86/visit/develop/release/build-mb-3.5.0-darwin-24-arm64-release/thirdparty_shared/third_party/python/3.13.9/darwin-arm64/bin/python3 -m pagefind --include-characters "_-./:+#<>" --exclude-selectors "a.headerlink" --site _build
+% python3 -m http.server 8000
+%
+%
+# Introduction to Silo
 
 ## Overview
 

--- a/docs/python.md
+++ b/docs/python.md
@@ -91,6 +91,30 @@ Type "help", "copyright", "credits" or "license" for more info.
 
 {{ EndFunc }}
 
+## `Silo.ShowErrors()`
+
+* **Summary:** Manipulate Silo library error handling and reporting
+
+* **C Signature:**
+
+  ```
+  NoneType Silo.ShowErrors(int level)
+  ```
+
+* **Arguments:**
+
+  Arg name | Description
+  :---|:---
+  `level` | [required int] one of `DB_NONE`, `DB_TOP`, `DB_ALL`, `DB_ALL_AND_DRVR` or `DB_ABORT`
+
+
+* **Description:**
+
+  Controls the Silo library's error handling and reporting behavior.
+  See [`DBShowErrors()`](./globals.md#dbshowerrors).
+
+{{ EndFunc }}
+
 ## `<DBfile>.GetToc()`
 
 * **Summary:** Get the table of contents

--- a/src/hdf5_drv/silo_hdf5.c
+++ b/src/hdf5_drv/silo_hdf5.c
@@ -7291,8 +7291,36 @@ db_hdf5_GetComponentStuff(DBfile *_dbfile, char const *objname, char const *comp
         if (mno>=n) {
             if (mnof == -1)
             {
-                db_perror(compname, E_NOTFOUND, me);
-                UNWIND();
+                /* We did NOT find any member of the specified object matching compname.
+                   However, we could be here for one of those cases where we added a faux
+                   "datatype" member to a generic object returned from DBGetObject. The
+                   difference is that there we were building a generic Silo run-time object
+                   and here, we're interrogating the actual HDF5 struct-like object stored
+                   to the file. Apparently, and for reasons I don't understand, the HDF5
+                   driver adds a "datatype" member to the struct-like objects stored to the
+                   file ONLY when it is NOT DB_FLOAT or DB_DOUBLE. The best we can do is
+                   return a value indicating we cannot fully determine the value for "datatype". */
+                if (!strncmp(compname, "datatype", 8))
+                {
+                    if (just_get_datatype == 0)
+                    {
+                        retval = malloc(sizeof(int));
+                        *((int*)retval) = DB_FLOAT_OR_DOUBLE;
+                        if (nvals) *nvals = 1;
+                        goto endStuff;
+                    }
+                    else
+                    {
+                        *just_get_datatype = DB_INT;
+                        if (nvals) *nvals = 1;
+                        goto endStuff;
+                    }
+                }
+                else
+                {
+                    db_perror(compname, E_NOTFOUND, me);
+                    UNWIND();
+                }
             }
             mno = mnof;
         }
@@ -7401,6 +7429,8 @@ db_hdf5_GetComponentStuff(DBfile *_dbfile, char const *objname, char const *comp
                 }
             }
         }
+
+endStuff:
         
         /* Release objects */
         if (mnofname) free(mnofname);

--- a/src/silo/silo.h.in
+++ b/src/silo/silo.h.in
@@ -397,7 +397,8 @@ typedef enum {
     DB_FLOATA=24,
     DB_DOUBLEA=25,
 
-    DB_NOTYPE=26           /*unknown type */
+    DB_NOTYPE=26,          /*unknown type */
+    DB_FLOAT_OR_DOUBLE=27  /* for "datatype" component queries on HDF5 driver */
 } DBdatatype;
 
 /* Flags for DBCreate (used only in DBCreate) */

--- a/tests/test_read.py
+++ b/tests/test_read.py
@@ -110,3 +110,24 @@ print("mesh1['coord0']=",db.GetVarInfo("mesh1",1)['coord0'])
 db.SetDir("/")
 toc = db.GetToc()
 db.Close()
+
+# Test a really, really old Silo file to make sure we at least
+# don't crash the python module
+def look_for_file(fname):
+    if os.access(fname,os.R_OK):
+        return fname
+    elif os.access("../../%s"%fname,os.R_OK):
+        return "../../%s"%fname
+    elif os.access("./bin/%s"%fname,os.R_OK):
+        return "./bin/%s"%fname
+    elif os.access("../all_tests/%s"%fname,os.R_OK):
+        return "../all_tests/%s"%fname
+
+db = Silo.Open(look_for_file("pion0244.silo"))
+toc = db.GetToc()
+objName = toc.qmesh_names[0]
+try:
+    print(db.GetVarInfo(objName,1))
+except Silo.SiloException:
+    pass
+db.Close()

--- a/tools/python/pydbfile.cpp
+++ b/tools/python/pydbfile.cpp
@@ -383,12 +383,12 @@ static PyObject *DBfile_DBGetVarInfo(PyObject *self, PyObject *args)
 
         // Handle possible incomplete datatype information in generic objects from HDF5 driver by
         // overriding a DB_FLOAT_OR_DOUBLE datatype value with whatever the generic object's pdb
-        // component holds.
+        // component metadata holds.
         if (compname == "datatype" && 
             type == DB_INT && 
             !pdbname.compare(0, 4, "'<i>") &&
             *((int*)comp) == DB_FLOAT_OR_DOUBLE)
-            *((int*)comp) = std::stoi(pdbname.substr(4));
+            *((int*)comp) = std::stoi(pdbname.substr(4)); // get value from pdb component
         
         int ival = -1;
         switch (type)

--- a/tools/python/pydbfile.cpp
+++ b/tools/python/pydbfile.cpp
@@ -348,7 +348,15 @@ static PyObject *DBfile_DBGetVarInfo(PyObject *self, PyObject *args)
     // being read and, if it is a compressed mesh/var object, do the work
     // necessary to prepare for its decompression. Too much work for now.
     //
+    db_errno = 0;
     DBobject *silo_obj = DBGetObject(db, str);
+    if (silo_obj == NULL)
+    {
+        char errmsg[256];
+        snprintf(errmsg, sizeof(errmsg), "DBGetObject returns NULL for \"%s\" (%s)", str, DBErrString());
+        SiloErrorFunc(errmsg);
+        return NULL;
+    }
 
     PyObject *retval = PyDict_New();
     PyDict_SetItemString(retval, "name", PyString_FromString(silo_obj->name));
@@ -367,11 +375,21 @@ static PyObject *DBfile_DBGetVarInfo(PyObject *self, PyObject *args)
             if (!comp)
             {
                 char msg[256];
-                snprintf(msg, sizeof(msg), "Unable to get component \"%s\" for object \%s\"", compname.c_str(), str);
+                snprintf(msg, sizeof(msg), "Unable to get component \"%s\" for object \"%s\"", compname.c_str(), str);
                 SiloErrorFunc(msg);
                 continue;
             }
         }
+
+        // Handle possible incomplete datatype information in generic objects from HDF5 driver by
+        // overriding a DB_FLOAT_OR_DOUBLE datatype value with whatever the generic object's pdb
+        // component holds.
+        if (compname == "datatype" && 
+            type == DB_INT && 
+            !pdbname.compare(0, 4, "'<i>") &&
+            *((int*)comp) == DB_FLOAT_OR_DOUBLE)
+            *((int*)comp) = std::stoi(pdbname.substr(4));
+        
         int ival = -1;
         switch (type)
         {


### PR DESCRIPTION
Resolves #567